### PR TITLE
UI: Check available features from backend

### DIFF
--- a/dashboards-notifications/common/index.ts
+++ b/dashboards-notifications/common/index.ts
@@ -39,6 +39,7 @@ export const NODE_API = Object.freeze({
   UPDATE_CONFIG: `${NODE_API_BASE_PATH}/update_config`,
   GET_EVENTS: `${NODE_API_BASE_PATH}/get_events`,
   GET_EVENT: `${NODE_API_BASE_PATH}/get_event`,
+  AVAILABLE_FEATURES: `${NODE_API_BASE_PATH}/features`,
 });
 
 // TODO change to _plugins when backend updates
@@ -46,6 +47,7 @@ const OPENSEARCH_API_BASE_PATH = '/_opensearch/_notifications';
 export const OPENSEARCH_API = Object.freeze({
   CONFIGS: `${OPENSEARCH_API_BASE_PATH}/configs`,
   EVENTS: `${OPENSEARCH_API_BASE_PATH}/events`,
+  FEATURES: `${OPENSEARCH_API_BASE_PATH}/features`,
 });
 
 export const REQUEST = Object.freeze({

--- a/dashboards-notifications/package.json
+++ b/dashboards-notifications/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
-    "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
+    "test": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
     "plugin_helpers": "node ../../scripts/plugin_helpers"

--- a/dashboards-notifications/public/pages/Channels/__tests__/ChannelControls.test.tsx
+++ b/dashboards-notifications/public/pages/Channels/__tests__/ChannelControls.test.tsx
@@ -26,6 +26,8 @@
 
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
+import { mainStateMock } from '../../../../test/mocks/serviceMock';
+import { MainContext } from '../../Main/Main';
 import { ChannelControls } from '../components/ChannelControls';
 
 describe('<ChannelControls /> spec', () => {
@@ -33,12 +35,14 @@ describe('<ChannelControls /> spec', () => {
     const onSearchChange = jest.fn();
     const onFiltersChange = jest.fn();
     const { container } = render(
-      <ChannelControls
-        search=""
-        onSearchChange={onSearchChange}
-        filters={{}}
-        onFiltersChange={onFiltersChange}
-      />
+      <MainContext.Provider value={mainStateMock}>
+        <ChannelControls
+          search=""
+          onSearchChange={onSearchChange}
+          filters={{}}
+          onFiltersChange={onFiltersChange}
+        />
+      </MainContext.Provider>
     );
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -47,12 +51,14 @@ describe('<ChannelControls /> spec', () => {
     const onSearchChange = jest.fn();
     const onFiltersChange = jest.fn();
     const utils = render(
-      <ChannelControls
-        search=""
-        onSearchChange={onSearchChange}
-        filters={{}}
-        onFiltersChange={onFiltersChange}
-      />
+      <MainContext.Provider value={mainStateMock}>
+        <ChannelControls
+          search=""
+          onSearchChange={onSearchChange}
+          filters={{}}
+          onFiltersChange={onFiltersChange}
+        />
+      </MainContext.Provider>
     );
     const input = utils.getByPlaceholderText('Search');
 
@@ -64,12 +70,14 @@ describe('<ChannelControls /> spec', () => {
     const onSearchChange = jest.fn();
     const onFiltersChange = jest.fn();
     const utils = render(
-      <ChannelControls
-        search=""
-        onSearchChange={onSearchChange}
-        filters={{}}
-        onFiltersChange={onFiltersChange}
-      />
+      <MainContext.Provider value={mainStateMock}>
+        <ChannelControls
+          search=""
+          onSearchChange={onSearchChange}
+          filters={{}}
+          onFiltersChange={onFiltersChange}
+        />
+      </MainContext.Provider>
     );
     fireEvent.click(utils.getByText('Status'));
     fireEvent.click(utils.getByText('Active'));

--- a/dashboards-notifications/public/pages/Channels/__tests__/Channels.test.tsx
+++ b/dashboards-notifications/public/pages/Channels/__tests__/Channels.test.tsx
@@ -28,24 +28,28 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MOCK_DATA } from '../../../../test/mocks/mockData';
 import { routerComponentPropsMock } from '../../../../test/mocks/routerPropsMock';
-import { coreServicesMock } from '../../../../test/mocks/serviceMock';
+import {
+  coreServicesMock,
+  mainStateMock,
+} from '../../../../test/mocks/serviceMock';
 import { CoreServicesContext } from '../../../components/coreServices';
+import { MainContext } from '../../Main/Main';
 import { Channels } from '../Channels';
 
 describe('<Channels/> spec', () => {
   it('renders the empty component', () => {
     const notificationServiceMock = jest.fn() as any;
-    const getChannels = jest.fn(
-      async (queryObject: object) => []
-    );
+    const getChannels = jest.fn(async (queryObject: object) => []);
     notificationServiceMock.notificationService = { getChannels };
     const utils = render(
-      <CoreServicesContext.Provider value={coreServicesMock}>
-        <Channels
-          {...routerComponentPropsMock}
-          notificationService={notificationServiceMock}
-        />
-      </CoreServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <CoreServicesContext.Provider value={coreServicesMock}>
+          <Channels
+            {...routerComponentPropsMock}
+            notificationService={notificationServiceMock}
+          />
+        </CoreServicesContext.Provider>
+      </MainContext.Provider>
     );
     expect(utils.container.firstChild).toMatchSnapshot();
   });
@@ -57,12 +61,14 @@ describe('<Channels/> spec', () => {
     const notificationService = jest.fn() as any;
     notificationService.getChannels = getChannels;
     const utils = render(
-      <CoreServicesContext.Provider value={coreServicesMock}>
-        <Channels
-          {...routerComponentPropsMock}
-          notificationService={notificationService}
-        />
-      </CoreServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <CoreServicesContext.Provider value={coreServicesMock}>
+          <Channels
+            {...routerComponentPropsMock}
+            notificationService={notificationService}
+          />
+        </CoreServicesContext.Provider>
+      </MainContext.Provider>
     );
 
     await waitFor(() => expect(getChannels).toBeCalled());

--- a/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
       "notificationService": NotificationService {
         "createConfig": [Function],
         "deleteConfigs": [Function],
+        "getAvailableFeatures": [Function],
         "getChannel": [Function],
         "getChannels": [Function],
         "getConfig": [Function],

--- a/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
       "notificationService": NotificationService {
         "createConfig": [Function],
         "deleteConfigs": [Function],
+        "getAvailableFeatures": [Function],
         "getChannel": [Function],
         "getChannels": [Function],
         "getConfig": [Function],
@@ -1859,6 +1860,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
       "notificationService": NotificationService {
         "createConfig": [Function],
         "deleteConfigs": [Function],
+        "getAvailableFeatures": [Function],
         "getChannel": [Function],
         "getChannels": [Function],
         "getConfig": [Function],

--- a/dashboards-notifications/public/pages/Channels/components/ChannelControls.tsx
+++ b/dashboards-notifications/public/pages/Channels/components/ChannelControls.tsx
@@ -34,11 +34,9 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import _ from 'lodash';
-import React, { useState } from 'react';
-import {
-  CHANNEL_TYPE,
-  NOTIFICATION_SOURCE,
-} from '../../../../public/utils/constants';
+import React, { useContext, useState } from 'react';
+import { NOTIFICATION_SOURCE } from '../../../../public/utils/constants';
+import { MainContext } from '../../Main/Main';
 import { ChannelFiltersType } from '../types';
 
 interface ChannelControlsProps {
@@ -49,6 +47,7 @@ interface ChannelControlsProps {
 }
 
 export const ChannelControls = (props: ChannelControlsProps) => {
+  const mainStateContext = useContext(MainContext)!;
   const [isStatePopoverOpen, setIsStatePopoverOpen] = useState(false);
   const [stateItems, setStateItems] = useState([
     { field: 'true', display: 'Active', checked: 'off' },
@@ -56,7 +55,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
   ]);
   const [isTypePopoverOpen, setIsTypePopoverOpen] = useState(false);
   const [typeItems, setTypeItems] = useState(
-    Object.entries(CHANNEL_TYPE).map(([key, value]) => ({
+    Object.entries(mainStateContext.availableFeatures).map(([key, value]) => ({
       field: key,
       display: value,
       checked: 'off',
@@ -105,7 +104,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
       case 'type':
         setTypeItems(newItems);
         newFilters.type = checkedItems;
-        break
+        break;
       default:
         break;
     }
@@ -180,9 +179,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
                 <EuiFilterSelectItem
                   key={`channel-type-filter-${index}`}
                   checked={item.checked === 'on' ? 'on' : undefined}
-                  onClick={() =>
-                    updateItem(typeItems, index, 'type')
-                  }
+                  onClick={() => updateItem(typeItems, index, 'type')}
                 >
                   {item.display}
                 </EuiFilterSelectItem>
@@ -208,9 +205,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
                 <EuiFilterSelectItem
                   key={`channel-source-filter-${index}`}
                   checked={item.checked === 'on' ? 'on' : undefined}
-                  onClick={() =>
-                    updateItem(sourceItems, index, 'source')
-                  }
+                  onClick={() => updateItem(sourceItems, index, 'source')}
                 >
                   {item.display}
                 </EuiFilterSelectItem>

--- a/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../utils/constants';
 import { getErrorMessage } from '../../utils/helpers';
 import { HeaderItemType } from '../Channels/types';
+import { MainContext } from '../Main/Main';
 import { ChannelAvailabilityPanel } from './components/ChannelAvailabilityPanel';
 import { ChannelNamePanel } from './components/ChannelNamePanel';
 import { ChimeSettings } from './components/ChimeSettings';
@@ -93,6 +94,7 @@ export function CreateChannel(props: CreateChannelsProps) {
 
   const coreContext = useContext(CoreServicesContext)!;
   const servicesContext = useContext(ServicesContext)!;
+  const mainStateContext = useContext(MainContext)!;
   const id = props.match.params.id;
   const prevURL =
     props.edit && queryString.parse(props.location.search).from === 'details'
@@ -107,10 +109,12 @@ export function CreateChannel(props: CreateChannelsProps) {
 
   const channelTypeOptions: Array<EuiSuperSelectOption<
     keyof typeof CHANNEL_TYPE
-  >> = Object.entries(CHANNEL_TYPE).map(([key, value]) => ({
-    value: key as keyof typeof CHANNEL_TYPE,
-    inputDisplay: value,
-  }));
+  >> = Object.entries(mainStateContext.availableFeatures).map(
+    ([key, value]) => ({
+      value: key as keyof typeof CHANNEL_TYPE,
+      inputDisplay: value,
+    })
+  );
   const [channelType, setChannelType] = useState(channelTypeOptions[0].value);
 
   const [slackWebhook, setSlackWebhook] = useState('');
@@ -467,7 +471,7 @@ export function CreateChannel(props: CreateChannelsProps) {
                         props.edit ? 'updated' : 'created'
                       }.`
                     );
-                    setTimeout(() => location.assign(prevURL), SERVER_DELAY);
+                    setTimeout(() => (location.hash = prevURL), SERVER_DELAY);
                   })
                   .catch((error) => {
                     setLoading(false);

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/CreateChannel.test.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/CreateChannel.test.tsx
@@ -30,21 +30,27 @@ import { RouteComponentProps } from 'react-router-dom';
 import { MOCK_DATA } from '../../../../test/mocks/mockData';
 import {
   coreServicesMock,
+  mainStateMock,
   notificationServiceMock,
 } from '../../../../test/mocks/serviceMock';
 import { CoreServicesContext } from '../../../components/coreServices';
 import { ServicesContext } from '../../../services';
+import { MainContext } from '../../Main/Main';
 import { CreateChannel } from '../CreateChannel';
 
 describe('<CreateChannel/> spec', () => {
   it('renders the component', () => {
     const props = { match: { params: { id: 'test' } } };
     const utils = render(
-      <ServicesContext.Provider value={notificationServiceMock}>
-        <CoreServicesContext.Provider value={coreServicesMock}>
-          <CreateChannel {...(props as RouteComponentProps<{ id: string }>)} />
-        </CoreServicesContext.Provider>
-      </ServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMock}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel
+              {...(props as RouteComponentProps<{ id: string }>)}
+            />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
     );
     utils.getByTestId('create-channel-create-button').click();
     utils.getByText('Alerting').click();
@@ -69,14 +75,16 @@ describe('<CreateChannel/> spec', () => {
       match: { params: { id: 'test' } },
     };
     const utilsSlack = render(
-      <ServicesContext.Provider value={notificationServiceMockSlack}>
-        <CoreServicesContext.Provider value={coreServicesMock}>
-          <CreateChannel
-            {...(props as RouteComponentProps<{ id: string }>)}
-            edit={true}
-          />
-        </CoreServicesContext.Provider>
-      </ServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMockSlack}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel
+              {...(props as RouteComponentProps<{ id: string }>)}
+              edit={true}
+            />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
     );
 
     await waitFor(() => {
@@ -107,14 +115,16 @@ describe('<CreateChannel/> spec', () => {
       match: { params: { id: 'test' } },
     };
     const utilsChime = render(
-      <ServicesContext.Provider value={notificationServiceMockChime}>
-        <CoreServicesContext.Provider value={coreServicesMock}>
-          <CreateChannel
-            {...(props as RouteComponentProps<{ id: string }>)}
-            edit={true}
-          />
-        </CoreServicesContext.Provider>
-      </ServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMockChime}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel
+              {...(props as RouteComponentProps<{ id: string }>)}
+              edit={true}
+            />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
     );
 
     await waitFor(() => {
@@ -135,21 +145,25 @@ describe('<CreateChannel/> spec', () => {
     notificationServiceMockEmail.notificationService = {
       getChannel: getEmailChannel,
       getSenders: jest.fn(async (query) => MOCK_DATA.senders),
-      getEmailConfigDetails: jest.fn(async (channel) => Promise.resolve(channel))
+      getEmailConfigDetails: jest.fn(async (channel) =>
+        Promise.resolve(channel)
+      ),
     };
     const props = {
       location: { search: '' },
       match: { params: { id: 'test' } },
     };
     const utilsEmail = render(
-      <ServicesContext.Provider value={notificationServiceMockEmail}>
-        <CoreServicesContext.Provider value={coreServicesMock}>
-          <CreateChannel
-            {...(props as RouteComponentProps<{ id: string }>)}
-            edit={true}
-          />
-        </CoreServicesContext.Provider>
-      </ServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMockEmail}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel
+              {...(props as RouteComponentProps<{ id: string }>)}
+              edit={true}
+            />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
     );
 
     await waitFor(() => {
@@ -170,14 +184,16 @@ describe('<CreateChannel/> spec', () => {
       match: { params: { id: 'test' } },
     };
     const utilsWebhook = render(
-      <ServicesContext.Provider value={notificationServiceMockWebhook}>
-        <CoreServicesContext.Provider value={coreServicesMock}>
-          <CreateChannel
-            {...(props as RouteComponentProps<{ id: string }>)}
-            edit={true}
-          />
-        </CoreServicesContext.Provider>
-      </ServicesContext.Provider>
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMockWebhook}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel
+              {...(props as RouteComponentProps<{ id: string }>)}
+              edit={true}
+            />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
     );
 
     await waitFor(() => {

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<ChimeSettings /> spec renders the component 1`] = `
       >
         <input
           class="euiFieldText euiFieldText--fullWidth"
-          data-test-subj="create-channel-slack-webhook-input"
+          data-test-subj="create-channel-chime-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."
           type="text"
@@ -69,7 +69,7 @@ exports[`<ChimeSettings /> spec renders the component with error 1`] = `
         <input
           aria-describedby="random_html_id-error-0"
           class="euiFieldText euiFieldText--fullWidth"
-          data-test-subj="create-channel-slack-webhook-input"
+          data-test-subj="create-channel-chime-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."
           type="text"

--- a/dashboards-notifications/public/pages/CreateChannel/components/ChimeSettings.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/components/ChimeSettings.tsx
@@ -46,7 +46,7 @@ export function ChimeSettings(props: ChimeSettingsProps) {
     >
       <EuiFieldText
         fullWidth
-        data-test-subj="create-channel-slack-webhook-input"
+        data-test-subj="create-channel-chime-webhook-input"
         placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."
         value={props.chimeWebhook}
         onChange={(e) => props.setChimeWebhook(e.target.value)}

--- a/dashboards-notifications/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/dashboards-notifications/public/pages/Emails/CreateRecipientGroup.tsx
@@ -183,7 +183,7 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
                     }.`
                   );
                   setTimeout(
-                    () => location.assign(`#${ROUTES.EMAIL_GROUPS}`),
+                    () => location.hash = `#${ROUTES.EMAIL_GROUPS}`,
                     SERVER_DELAY
                   );
                 })

--- a/dashboards-notifications/public/pages/Emails/CreateSender.tsx
+++ b/dashboards-notifications/public/pages/Emails/CreateSender.tsx
@@ -186,7 +186,7 @@ export function CreateSender(props: CreateSenderProps) {
                     }.`
                   );
                   setTimeout(
-                    () => location.assign(`#${ROUTES.EMAIL_GROUPS}`),
+                    () => location.hash = `#${ROUTES.EMAIL_GROUPS}`,
                     SERVER_DELAY
                   );
                 })

--- a/dashboards-notifications/public/pages/Main/Main.tsx
+++ b/dashboards-notifications/public/pages/Main/Main.tsx
@@ -63,6 +63,7 @@ interface MainProps extends RouteComponentProps {}
 
 export interface MainState {
   isChannelConfigured: boolean;
+  availableFeatures: Partial<typeof CHANNEL_TYPE>;
 }
 
 export const MainContext = createContext<MainState | null>(null);
@@ -74,10 +75,13 @@ export default class Main extends Component<MainProps, MainState> {
     super(props);
     this.state = {
       isChannelConfigured: true,
+      availableFeatures: CHANNEL_TYPE,
     };
   }
 
   async componentDidMount() {
+    const availableFeatures = await this.context.notificationService.getAvailableFeatures();
+    if (availableFeatures != null) this.setState({ availableFeatures });
     try {
       const isChannelConfigured = await this.context.notificationService.getChannels(
         {

--- a/dashboards-notifications/public/pages/Notifications/__tests__/filterHelpers.test.tsx
+++ b/dashboards-notifications/public/pages/Notifications/__tests__/filterHelpers.test.tsx
@@ -25,9 +25,9 @@
  */
 
 import { fireEvent, render } from '@testing-library/react';
+import { CHANNEL_TYPE } from '../../../utils/constants';
 import { FilterType } from '../components/SearchBar/Filter/Filters';
 import {
-  filterToQueryString,
   getFilterFieldOptions,
   getFilterOperatorOptions,
   getOperatorString,
@@ -69,7 +69,9 @@ describe('test filter helper functions', () => {
 
   it('renders textfield', () => {
     const setValue = jest.fn();
-    const utils = render(getValueComponent('Channel', 'is', 0, setValue));
+    const utils = render(
+      getValueComponent('Channel', 'is', 0, setValue, CHANNEL_TYPE)
+    );
     expect(utils.container.firstChild).toMatchSnapshot();
 
     const input = utils.container.querySelector('input')!;
@@ -80,20 +82,20 @@ describe('test filter helper functions', () => {
   it('renders combobox', () => {
     const setValue = jest.fn();
     expect(
-      render(getValueComponent('Channel type', 'is', 0, setValue)).container
-        .firstChild
+      render(getValueComponent('Channel type', 'is', 0, setValue, CHANNEL_TYPE))
+        .container.firstChild
     ).toMatchSnapshot();
     expect(
-      render(getValueComponent('Severity', 'is', 0, setValue)).container
-        .firstChild
+      render(getValueComponent('Severity', 'is', 0, setValue, CHANNEL_TYPE))
+        .container.firstChild
     ).toMatchSnapshot();
     expect(
-      render(getValueComponent('Source', 'is', 0, setValue)).container
-        .firstChild
+      render(getValueComponent('Source', 'is', 0, setValue, CHANNEL_TYPE))
+        .container.firstChild
     ).toMatchSnapshot();
     expect(
-      render(getValueComponent('Status', 'is', 0, setValue)).container
-        .firstChild
+      render(getValueComponent('Status', 'is', 0, setValue, CHANNEL_TYPE))
+        .container.firstChild
     ).toMatchSnapshot();
   });
 

--- a/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/FilterEditPopover.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/FilterEditPopover.tsx
@@ -34,7 +34,8 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
-import React, { useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
+import { MainContext } from '../../../../Main/Main';
 import {
   FilterOperatorType,
   FilterFieldType,
@@ -53,6 +54,7 @@ interface FilterEditPopoverProps {
 }
 
 export function FilterEditPopover(props: FilterEditPopoverProps) {
+  const mainStateContext = useContext(MainContext)!;
   const [selectedFieldOptions, setSelectedFieldOptions] = useState<
     Array<EuiComboBoxOptionOption<string>>
   >(props.filter ? [{ label: props.filter.field }] : []);
@@ -135,7 +137,8 @@ export function FilterEditPopover(props: FilterEditPopoverProps) {
           selectedFieldOptions[0].label as FilterFieldType,
           selectedOperatorOptions[0].label as FilterOperatorType,
           filterValue,
-          setFilterValue
+          setFilterValue,
+          mainStateContext.availableFeatures
         )}
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">

--- a/dashboards-notifications/public/pages/Notifications/components/SearchBar/utils/filterHelpers.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/SearchBar/utils/filterHelpers.tsx
@@ -93,7 +93,8 @@ export const getValueComponent = (
   field: FilterFieldType,
   operator: FilterOperatorType,
   value: any,
-  setValue: (v: any) => void
+  setValue: (v: any) => void,
+  availableFeatures: { [feature: string]: string }
 ) => {
   // only Channel filters should be inputbox, others should be combobox
   if (field === 'Channel')
@@ -113,7 +114,7 @@ export const getValueComponent = (
   let options;
 
   if (field === 'Channel type')
-    options = Object.entries(CHANNEL_TYPE).map(([key, value]) => ({
+    options = Object.entries(availableFeatures).map(([key, value]) => ({
       label: value,
       value: key,
     }));

--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -31,6 +31,7 @@ import {
   RecipientGroupItemType,
   SenderItemType,
 } from '../../models/interfaces';
+import { CHANNEL_TYPE } from '../utils/constants';
 import {
   configListToChannels,
   configListToRecipientGroups,
@@ -159,5 +160,25 @@ export default class NotificationService {
   getRecipientGroup = async (id: string): Promise<RecipientGroupItemType> => {
     const response = await this.getConfig(id);
     return configToRecipientGroup(response.config_list[0]);
+  };
+
+  getAvailableFeatures = async () => {
+    try {
+      const channels = (await this.httpClient
+        .get(NODE_API.AVAILABLE_FEATURES)
+        .then((response) => response.config_type_list)) as Array<
+        keyof typeof CHANNEL_TYPE
+      >;
+      const channelTypes: Partial<typeof CHANNEL_TYPE> = {};
+      for (let i = 0; i < channels.length; i++) {
+        const channel = channels[i];
+        if (!CHANNEL_TYPE[channel]) continue;
+        channelTypes[channel] = CHANNEL_TYPE[channel];
+      }
+      return channelTypes;
+    } catch (error) {
+      console.error('error fetching available features', error);
+      return null;
+    }
   };
 }

--- a/dashboards-notifications/server/clusters/notificationsPlugin.ts
+++ b/dashboards-notifications/server/clusters/notificationsPlugin.ts
@@ -107,4 +107,11 @@ export function NotificationsPlugin(Client: any, config: any, components: any) {
     method: 'GET',
   });
 
+  notifications.getAvailableFeatures = clientAction({
+    url: {
+      fmt: OPENSEARCH_API.FEATURES,
+    },
+    method: 'GET',
+  });
+
 }

--- a/dashboards-notifications/server/routes/configRoutes.ts
+++ b/dashboards-notifications/server/routes/configRoutes.ts
@@ -192,4 +192,28 @@ export function configRoutes(router: IRouter) {
       }
     }
   );
+
+  router.get(
+    {
+      path: NODE_API.AVAILABLE_FEATURES,
+      validate: false,
+    },
+    async (context, request, response) => {
+      // @ts-ignore
+      const client: ILegacyScopedClusterClient = context.notificationsContext.notificationsClient.asScoped(
+        request
+      );
+      try {
+        const resp = await client.callAsCurrentUser(
+          'notifications.getAvailableFeatures'
+        );
+        return response.ok({ body: resp });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
 }

--- a/dashboards-notifications/test/mocks/serviceMock.ts
+++ b/dashboards-notifications/test/mocks/serviceMock.ts
@@ -25,7 +25,9 @@
  */
 
 import { CoreStart } from 'opensearch-dashboards/public';
+import { MainState } from '../../public/pages/Main/Main';
 import { EventService, NotificationService } from '../../public/services';
+import { CHANNEL_TYPE } from '../../public/utils/constants';
 import httpClientMock from './httpClientMock';
 
 const coreServicesMock = ({
@@ -51,4 +53,9 @@ const notificationServiceMock = {
   eventService: eventServiceMock,
 };
 
-export { notificationServiceMock, coreServicesMock };
+const mainStateMock: MainState = {
+  isChannelConfigured: true,
+  availableFeatures: CHANNEL_TYPE,
+};
+
+export { notificationServiceMock, coreServicesMock, mainStateMock };


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
- creating channel and filtering by channel type are now limited to the channel types returned by `/_opensearch/_notifications/features` api
- update tests
- workaround a cypress issue (id 3994) by updating `location.hash` directly instead of `location.assign`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
