### PR TITLE
Add unit test for SPI Smtp email functionality

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -28,7 +28,7 @@ on: [push, pull_request]
 env:
   OPENSEARCH_VERSION: '1.0'
   COMMON_UTILS_VERSION: main
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0-rc1
+  OPENSEARCH_PLUGIN_VERSION: 1.0.0
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
           ref: ${{ env.OPENSEARCH_VERSION }}
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils

--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -27,8 +27,7 @@ on: [push, pull_request]
 
 env:
   OPENSEARCH_VERSION: '1.0'
-  COMMON_UTILS_VERSION: main
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0
+  COMMON_UTILS_VERSION: '1.0'
 
 jobs:
   build:
@@ -60,7 +59,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_PLUGIN_VERSION }}
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}.0
 
       # notifications
       - name: Checkout Notifications
@@ -69,7 +68,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd notifications
-          ./gradlew build -x :integTest -Dopensearch.version=${{ env.OPENSEARCH_PLUGIN_VERSION }} # exclude integTest task to avoid permission denied issue
+          ./gradlew build -x :integTest -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}.0 # exclude integTest task to avoid permission denied issue
 
       # - name: Upload coverage
       #   uses: codecov/codecov-action@v1

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -29,7 +29,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
         junit_version = System.getProperty("junit.version", "5.7.2")
     }
@@ -157,7 +157,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3" // ${kotlin_version} does not work for coroutines
-    compile "${group}:common-utils:1.0.0.0-rc1" // TODO: change to ${opensearch_version}
+    compile "${group}:common-utils:${opensearch_version}.0" // TODO: change to ${opensearch_version}
     compile ("software.amazon.awssdk:ses:2.16.75") {
         exclude module: 'annotations' // conflict with org.jetbrains:annotations, integTestRunner fails with error "codebase property already set"
     }

--- a/notifications/spi/build.gradle
+++ b/notifications/spi/build.gradle
@@ -134,11 +134,11 @@ dependencies {
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation(
-        'org.assertj:assertj-core:3.16.1',
-        'org.junit.jupiter:junit-jupiter-api:5.6.2',
-        "org.easymock:easymock:4.0.1",
-        "org.apache.logging.log4j:log4j-core:${versions.log4j}",
-        "org.opensearch.test:framework:${opensearch_version}"
+            'org.assertj:assertj-core:3.16.1',
+            'org.junit.jupiter:junit-jupiter-api:5.6.2',
+            "org.easymock:easymock:4.0.1",
+            "org.apache.logging.log4j:log4j-core:${versions.log4j}",
+            "org.opensearch.test:framework:${opensearch_version}",
     )
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
@@ -29,7 +29,7 @@ import javax.mail.internet.MimeMessage
 /**
  * This class handles the connections to the given Destination.
  */
-class DestinationEmailClient {
+open class DestinationEmailClient {
 
     companion object {
         private val log by logger(DestinationEmailClient::class.java)
@@ -40,7 +40,6 @@ class DestinationEmailClient {
 
     @Throws(Exception::class)
     fun execute(emailDestination: EmailDestination, message: MessageContent): DestinationMessageResponse {
-
         if (isMessageSizeOverLimit(message)) {
             return DestinationMessageResponse(
                 RestStatus.REQUEST_ENTITY_TOO_LARGE,
@@ -89,8 +88,9 @@ class DestinationEmailClient {
     /*
      * This method is useful for mocking the client
      */
+    // TODO remove open keyword after adding other framework that can mock final class/method. e.g. Mockito2 ?
     @Throws(Exception::class)
-    fun sendMessage(msg: Message?) {
+    open fun sendMessage(msg: Message?) {
         Transport.send(msg)
     }
 
@@ -105,7 +105,6 @@ class DestinationEmailClient {
     }
 
     private fun isMessageSizeOverLimit(message: MessageContent): Boolean {
-
         val approxAttachmentLength = if (message.fileData != null && message.fileName != null) {
             MINIMUM_EMAIL_HEADER_LENGTH + message.fileData.length + message.fileName.length
         } else {

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
@@ -45,8 +45,8 @@ class EmailDestination(
     init {
         when (destinationType) {
             "Smtp" -> {
-                require(!Strings.isNullOrEmpty(host)) { "host is null or empty" }
-                require(port > 0) { "port should be positive value" }
+                require(!Strings.isNullOrEmpty(host)) { "Host name should be provided" }
+                require(port > 0) { "Port should be positive value" }
                 validateEmail(fromAddress)
                 validateEmail(recipient)
             }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
@@ -27,6 +27,7 @@
 
 package org.opensearch.notifications.spi.utils
 
+import org.opensearch.common.Strings
 import java.net.URL
 
 fun validateUrl(urlString: String) {
@@ -37,6 +38,7 @@ fun validateUrl(urlString: String) {
 }
 
 fun validateEmail(email: String) {
+    require(!Strings.isNullOrEmpty(email)) { "FromAddress and recipient should be provided" }
     require(isValidEmail(email)) { "Invalid email address" }
 }
 

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
@@ -1,0 +1,109 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ *  Modifications Copyright OpenSearch Contributors. See
+ *  GitHub history for details.
+ */
+
+package org.opensearch.notifications.spi
+
+import junit.framework.Assert.assertEquals
+import org.easymock.EasyMock
+import org.junit.Assert
+import org.junit.Test
+import org.opensearch.notifications.spi.client.DestinationEmailClient
+import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
+import org.opensearch.notifications.spi.factory.SmtpEmailDestinationFactory
+import org.opensearch.notifications.spi.model.DestinationMessageResponse
+import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.EmailDestination
+import org.opensearch.rest.RestStatus
+import javax.mail.Message
+import javax.mail.MessagingException
+
+internal class EmailDestinationTests {
+    @Test
+    @Throws(Exception::class)
+    fun testSmtpEmailMessage() {
+        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK, "Success")
+        val emailClient: DestinationEmailClient = EasyMock.partialMockBuilder(DestinationEmailClient::class.java)
+            .addMockedMethod("sendMessage").createMock()
+        emailClient.sendMessage(EasyMock.anyObject(Message::class.java))
+        val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("Smtp" to smtpEmailDestinationFactory)
+
+        val subject = "Test SMTP Email subject"
+        val messageText = "{Message gughjhjlkh Body emoji test: :) :+1: " +
+            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+            "@All All Present member callout: @Present}"
+        val message = MessageContent(subject, messageText)
+        val destination = EmailDestination("abc", 465, "ssl", "test@abc.com", "to@abc.com", "Smtp")
+
+        val actualEmailResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
+        assertEquals(expectedEmailResponse.statusText, actualEmailResponse.statusText)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testSmtpFailingEmailMessage() {
+        val expectedEmailResponse = DestinationMessageResponse(
+            RestStatus.FAILED_DEPENDENCY,
+            "Couldn't connect to host, port: localhost, 55555; timeout -1"
+        )
+        val emailClient: DestinationEmailClient = EasyMock.partialMockBuilder(DestinationEmailClient::class.java)
+            .addMockedMethod("sendMessage").createMock()
+        emailClient.sendMessage(EasyMock.anyObject(Message::class.java))
+        EasyMock.expectLastCall<Any>()
+            .andThrow(MessagingException("Couldn't connect to host, port: localhost, 55555; timeout -1"))
+        EasyMock.replay(emailClient)
+        val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("Smtp" to smtpEmailDestinationFactory)
+
+        val subject = "Test SMTP Email subject"
+        val messageText = "{Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
+            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+            "@All All Present member callout: @Present}"
+        val message = MessageContent(subject, messageText)
+        val destination = EmailDestination("localhost", 55555, "none", "test@abc.com", "to@abc.com", "Smtp")
+
+        val actualEmailResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        EasyMock.verify(emailClient)
+        assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
+        assertEquals("sendEmail Error, status:${expectedEmailResponse.statusText}", actualEmailResponse.statusText)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testHostMissingEmailDestination() {
+        try {
+            EmailDestination("", 465, "ssl", "from@test.com", "to@test.com", "Smtp")
+        } catch (exception: Exception) {
+            Assert.assertEquals("Host name should be provided", exception.message)
+            throw exception
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInvalidPortEmailDestination() {
+        try {
+            EmailDestination("localhost", -1, "ssl", "from@test.com", "to@test.com", "Smtp")
+        } catch (exception: Exception) {
+            Assert.assertEquals("Port should be positive value", exception.message)
+            throw exception
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testMissingFromOrRecipientEmailDestination() {
+        try {
+            EmailDestination("localhost", 465, "ssl", "", "to@test.com", "Smtp")
+        } catch (exception: Exception) {
+            Assert.assertEquals("FromAddress and recipient should be provided", exception.message)
+            throw exception
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
- Add unit testing for SMTP email functionality in SPI
- Bump opensearch-notification to 1.0.0.0 to pass notification-opensearch CI

### Issues Resolved
#215 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
