### PR TITLE
Integrate get plugin feature/config type with SPI

### DIFF
--- a/dashboards-notifications/README.md
+++ b/dashboards-notifications/README.md
@@ -4,7 +4,7 @@ Dashboards Notifications plugin provides an interface that helps users to manage
 
 ## Documentation
 
-Please see our technical [documentation](https://docs-beta.opensearch.org/) to learn more about its features.
+Please see our technical [documentation](https://opensearch.org/docs) to learn more about its features.
 
 ## Setup
 
@@ -28,8 +28,8 @@ Ultimately, your directory structure should look like this:
 ```md
 .
 ├── OpenSearch Dashboards
-│   └── plugins
-│       └── dashboards-notifications
+│ └── plugins
+│ └── dashboards-notifications
 ```
 
 ## Build
@@ -37,7 +37,6 @@ Ultimately, your directory structure should look like this:
 To build the plugin's distributable zip simply run `yarn build`.
 
 Example output: `./build/notificationsDashboards*.zip`
-
 
 ## Run
 

--- a/dashboards-notifications/public/utils/constants.ts
+++ b/dashboards-notifications/public/utils/constants.ts
@@ -26,7 +26,7 @@
 
 export const DOCUMENTATION_LINK = '';
 export const ALERTING_DOCUMENTATION_LINK =
-  'https://docs-beta.opensearch.org/docs/alerting/monitors/#authenticate-sender-account';
+  'https://opensearch.org/docs/alerting/monitors/#authenticate-sender-account';
 
 export const ROUTES = Object.freeze({
   // notification

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationSpi.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationSpi.kt
@@ -31,14 +31,15 @@ import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.BaseDestination
+import org.opensearch.notifications.spi.setting.PluginSettings
 import java.security.AccessController
 import java.security.PrivilegedAction
 
 /**
- * This is a client facing Notification class to send the messages
- * to the Notification channels like chime, slack, webhooks, email etc
+ * This is a client facing NotificationSpi class to send the messages
+ * to the NotificationSpi channels like chime, slack, webhooks, email etc
  */
-object Notification {
+object NotificationSpi {
     /**
      * Send the notification message to the corresponding destination
      *
@@ -51,6 +52,28 @@ object Notification {
                 val destinationFactory = DestinationFactoryProvider.getFactory(destination.destinationType)
                 destinationFactory.sendMessage(destination, message)
             } as PrivilegedAction<DestinationMessageResponse>?
+        )
+    }
+
+    /**
+     * Get list of allowed destinations
+     */
+    fun getAllowedConfigTypes(): List<String> {
+        return AccessController.doPrivileged(
+            PrivilegedAction {
+                PluginSettings.allowedConfigTypes
+            } as PrivilegedAction<List<String>>?
+        )
+    }
+
+    /**
+     * Get map of plugin features
+     */
+    fun getPluginFeatures(): Map<String, String> {
+        return AccessController.doPrivileged(
+            PrivilegedAction {
+                PluginSettings.defaultSettings
+            } as PrivilegedAction<Map<String, String>>?
         )
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationSpiPlugin.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationSpiPlugin.kt
@@ -1,0 +1,72 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ *  Modifications Copyright OpenSearch Contributors. See
+ *  GitHub history for details.
+ */
+
+package org.opensearch.notifications.spi
+
+import org.opensearch.client.Client
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.io.stream.NamedWriteableRegistry
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.env.Environment
+import org.opensearch.env.NodeEnvironment
+import org.opensearch.notifications.spi.setting.PluginSettings
+import org.opensearch.notifications.spi.utils.logger
+import org.opensearch.plugins.Plugin
+import org.opensearch.repositories.RepositoriesService
+import org.opensearch.script.ScriptService
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.watcher.ResourceWatcherService
+import java.util.function.Supplier
+
+/**
+ *  This is a dummy plugin for SPI to load configurations
+ */
+internal class NotificationSpiPlugin : Plugin() {
+    lateinit var clusterService: ClusterService // initialized in createComponents()
+
+    internal companion object {
+        private val log by logger(NotificationSpiPlugin::class.java)
+
+        const val PLUGIN_NAME = "opensearch-notifications"
+        const val LOG_PREFIX = "notifications"
+    }
+    /**
+     * {@inheritDoc}
+     */
+    override fun getSettings(): List<Setting<*>> {
+        log.debug("$LOG_PREFIX:getSettings")
+        return PluginSettings.getAllSettings()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun createComponents(
+        client: Client,
+        clusterService: ClusterService,
+        threadPool: ThreadPool,
+        resourceWatcherService: ResourceWatcherService,
+        scriptService: ScriptService,
+        xContentRegistry: NamedXContentRegistry,
+        environment: Environment,
+        nodeEnvironment: NodeEnvironment,
+        namedWriteableRegistry: NamedWriteableRegistry,
+        indexNameExpressionResolver: IndexNameExpressionResolver,
+        repositoriesServiceSupplier: Supplier<RepositoriesService>
+    ): Collection<Any> {
+        log.debug("$LOG_PREFIX:createComponents")
+        this.clusterService = clusterService
+        PluginSettings.addSettingsUpdateConsumer(clusterService)
+        return listOf()
+    }
+}

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
@@ -40,7 +40,7 @@ open class DestinationEmailClient {
     fun execute(emailDestination: EmailDestination, message: MessageContent): DestinationMessageResponse {
         if (isMessageSizeOverLimit(message)) {
             return DestinationMessageResponse(
-                RestStatus.REQUEST_ENTITY_TOO_LARGE,
+                RestStatus.REQUEST_ENTITY_TOO_LARGE.status,
                 "Email size larger than ${PluginSettings.emailSizeLimit}"
             )
         }
@@ -73,13 +73,13 @@ open class DestinationEmailClient {
             log.debug("Sending Email-SMTP")
             SecurityAccess.doPrivileged { sendMessage(mimeMessage) }
             log.info("Email-SMTP sent")
-            DestinationMessageResponse(RestStatus.OK, "Success")
+            DestinationMessageResponse(RestStatus.OK.status, "Success")
         } catch (exception: SendFailedException) {
-            DestinationMessageResponse(RestStatus.BAD_GATEWAY, getMessagingExceptionText(exception))
+            DestinationMessageResponse(RestStatus.BAD_GATEWAY.status, getMessagingExceptionText(exception))
         } catch (exception: MailConnectException) {
-            DestinationMessageResponse(RestStatus.SERVICE_UNAVAILABLE, getMessagingExceptionText(exception))
+            DestinationMessageResponse(RestStatus.SERVICE_UNAVAILABLE.status, getMessagingExceptionText(exception))
         } catch (exception: MessagingException) {
-            DestinationMessageResponse(RestStatus.FAILED_DEPENDENCY, getMessagingExceptionText(exception))
+            DestinationMessageResponse(RestStatus.FAILED_DEPENDENCY.status, getMessagingExceptionText(exception))
         }
     }
 

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
@@ -42,11 +42,11 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.http.util.EntityUtils
-import org.opensearch.common.unit.TimeValue
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
 import org.opensearch.notifications.spi.model.destination.SlackDestination
 import org.opensearch.notifications.spi.model.destination.WebhookDestination
+import org.opensearch.notifications.spi.setting.PluginSettings
 import org.opensearch.notifications.spi.utils.OpenForTesting
 import org.opensearch.notifications.spi.utils.logger
 import org.opensearch.rest.RestStatus
@@ -72,11 +72,11 @@ class DestinationHttpClient {
 
     companion object {
         private val log by logger(DestinationHttpClient::class.java)
-        // TODO get the following constants from config
-        private const val MAX_CONNECTIONS = 60
-        private const val MAX_CONNECTIONS_PER_ROUTE = 20
-        private val TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(5).millis().toInt()
-        private val SOCKET_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(50).millis().toInt()
+//        // TODO get the following constants from config
+//        private const val MAX_CONNECTIONS = 60
+//        private const val MAX_CONNECTIONS_PER_ROUTE = 20
+//        private val TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(5).millis().toInt()
+//        private val SOCKET_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(50).millis().toInt()
 
         /**
          * all valid response status
@@ -94,13 +94,13 @@ class DestinationHttpClient {
 
         private fun createHttpClient(): CloseableHttpClient {
             val config: RequestConfig = RequestConfig.custom()
-                .setConnectTimeout(TIMEOUT_MILLISECONDS)
-                .setConnectionRequestTimeout(TIMEOUT_MILLISECONDS)
-                .setSocketTimeout(SOCKET_TIMEOUT_MILLISECONDS)
+                .setConnectTimeout(PluginSettings.connectionTimeout)
+                .setConnectionRequestTimeout(PluginSettings.connectionTimeout)
+                .setSocketTimeout(PluginSettings.socketTimeout)
                 .build()
             val connectionManager = PoolingHttpClientConnectionManager()
-            connectionManager.maxTotal = MAX_CONNECTIONS
-            connectionManager.defaultMaxPerRoute = MAX_CONNECTIONS_PER_ROUTE
+            connectionManager.maxTotal = PluginSettings.maxConnections
+            connectionManager.defaultMaxPerRoute = PluginSettings.maxConnectionsPerRoute
 
             return HttpClientBuilder.create()
                 .setDefaultRequestConfig(config)

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
@@ -72,12 +72,6 @@ class DestinationHttpClient {
 
     companion object {
         private val log by logger(DestinationHttpClient::class.java)
-//        // TODO get the following constants from config
-//        private const val MAX_CONNECTIONS = 60
-//        private const val MAX_CONNECTIONS_PER_ROUTE = 20
-//        private val TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(5).millis().toInt()
-//        private val SOCKET_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(50).millis().toInt()
-
         /**
          * all valid response status
          */

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/DestinationFactoryProvider.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/DestinationFactoryProvider.kt
@@ -21,10 +21,10 @@ internal object DestinationFactoryProvider {
 
     var destinationFactoryMap = mapOf(
         // TODO Add other channel
-        "Slack" to WebhookDestinationFactory(),
-        "Chime" to WebhookDestinationFactory(),
-        "Webhook" to WebhookDestinationFactory(),
-        "Smtp" to SmtpEmailDestinationFactory()
+        "slack" to WebhookDestinationFactory(),
+        "chime" to WebhookDestinationFactory(),
+        "webhook" to WebhookDestinationFactory(),
+        "smtp" to SmtpEmailDestinationFactory()
     )
 
     /**
@@ -36,5 +36,14 @@ internal object DestinationFactoryProvider {
     fun getFactory(destinationType: String): DestinationFactory<BaseDestination> {
         require(destinationFactoryMap.containsKey(destinationType)) { "Invalid channel type" }
         return destinationFactoryMap[destinationType] as DestinationFactory<BaseDestination>
+    }
+
+    /**
+     * Fetch the allowed destinations
+     *
+     * @return List<String> list of allowed destinations
+     */
+    fun getAllowedDestinationList(): List<String> {
+        return destinationFactoryMap.keys.toList()
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/DestinationFactoryProvider.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/DestinationFactoryProvider.kt
@@ -12,6 +12,7 @@
 package org.opensearch.notifications.spi.factory
 
 import org.opensearch.notifications.spi.model.destination.BaseDestination
+import org.opensearch.notifications.spi.model.destination.DestinationType
 
 /**
  * This class helps in fetching the right destination factory based on type
@@ -20,11 +21,11 @@ import org.opensearch.notifications.spi.model.destination.BaseDestination
 internal object DestinationFactoryProvider {
 
     var destinationFactoryMap = mapOf(
-        // TODO Add other channel
-        "slack" to WebhookDestinationFactory(),
-        "chime" to WebhookDestinationFactory(),
-        "webhook" to WebhookDestinationFactory(),
-        "smtp" to SmtpEmailDestinationFactory()
+        // TODO Add other destinations, ses, sns
+        DestinationType.SLACK to WebhookDestinationFactory(),
+        DestinationType.CHIME to WebhookDestinationFactory(),
+        DestinationType.CUSTOMWEBHOOK to WebhookDestinationFactory(),
+        DestinationType.SMTP to SmtpEmailDestinationFactory()
     )
 
     /**
@@ -33,17 +34,8 @@ internal object DestinationFactoryProvider {
      * @param destinationType [{@link DestinationType}]
      * @return DestinationFactory factory object for above destination type
      */
-    fun getFactory(destinationType: String): DestinationFactory<BaseDestination> {
+    fun getFactory(destinationType: DestinationType): DestinationFactory<BaseDestination> {
         require(destinationFactoryMap.containsKey(destinationType)) { "Invalid channel type" }
         return destinationFactoryMap[destinationType] as DestinationFactory<BaseDestination>
-    }
-
-    /**
-     * Fetch the allowed destinations
-     *
-     * @return List<String> list of allowed destinations
-     */
-    fun getAllowedDestinationList(): List<String> {
-        return destinationFactoryMap.keys.toList()
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/SmtpEmailDestinationFactory.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/SmtpEmailDestinationFactory.kt
@@ -46,19 +46,19 @@ internal class SmtpEmailDestinationFactory : DestinationFactory<EmailDestination
         } catch (addressException: AddressException) {
             log.error("Error sending Email: recipient parsing failed with status:${addressException.message}")
             DestinationMessageResponse(
-                RestStatus.BAD_REQUEST,
+                RestStatus.BAD_REQUEST.status,
                 "recipient parsing failed with status:${addressException.message}"
             )
         } catch (messagingException: MessagingException) {
             log.error("Error sending Email: Email message creation failed with status:${messagingException.message}")
             DestinationMessageResponse(
-                RestStatus.FAILED_DEPENDENCY,
+                RestStatus.FAILED_DEPENDENCY.status,
                 "Email message creation failed with status:${messagingException.message}"
             )
         } catch (ioException: IOException) {
             log.error("Error sending Email: Email message creation failed with status:${ioException.message}")
             DestinationMessageResponse(
-                RestStatus.FAILED_DEPENDENCY,
+                RestStatus.FAILED_DEPENDENCY.status,
                 "Email message creation failed with status:${ioException.message}"
             )
         } catch (illegalArgumentException: IllegalArgumentException) {
@@ -66,7 +66,7 @@ internal class SmtpEmailDestinationFactory : DestinationFactory<EmailDestination
                 "Error sending Email: Email message creation failed with status:${illegalArgumentException.message}"
             )
             DestinationMessageResponse(
-                RestStatus.FAILED_DEPENDENCY,
+                RestStatus.FAILED_DEPENDENCY.status,
                 "Email message creation failed with status:${illegalArgumentException.message}"
             )
         }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/WebhookDestinationFactory.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/factory/WebhookDestinationFactory.kt
@@ -41,10 +41,13 @@ internal class WebhookDestinationFactory : DestinationFactory<WebhookDestination
     override fun sendMessage(destination: WebhookDestination, message: MessageContent): DestinationMessageResponse {
         return try {
             val response = destinationHttpClient.execute(destination, message)
-            DestinationMessageResponse(RestStatus.OK, response)
+            DestinationMessageResponse(RestStatus.OK.status, response)
         } catch (exception: IOException) {
             log.error("Exception sending message: $message", exception)
-            DestinationMessageResponse(RestStatus.INTERNAL_SERVER_ERROR, "Failed to send message ${exception.message}")
+            DestinationMessageResponse(
+                RestStatus.INTERNAL_SERVER_ERROR.status,
+                "Failed to send message ${exception.message}"
+            )
         }
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/DestinationMessageResponse.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/DestinationMessageResponse.kt
@@ -27,12 +27,10 @@
 
 package org.opensearch.notifications.spi.model
 
-import org.opensearch.rest.RestStatus
-
 /**
  * Data class for storing destination message response per recipient.
  */
 class DestinationMessageResponse(
-    val statusCode: RestStatus,
+    val statusCode: Int,
     val statusText: String
 )

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/BaseDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/BaseDestination.kt
@@ -32,5 +32,5 @@ package org.opensearch.notifications.spi.model.destination
  */
 @SuppressWarnings("UnnecessaryAbstractClass")
 abstract class BaseDestination(
-    val destinationType: String
+    val destinationType: DestinationType
 )

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ChimeDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ChimeDestination.kt
@@ -32,4 +32,4 @@ package org.opensearch.notifications.spi.model.destination
  */
 class ChimeDestination(
     url: String,
-) : WebhookDestination(url, "chime")
+) : WebhookDestination(url, DestinationType.CHIME)

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ChimeDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ChimeDestination.kt
@@ -32,4 +32,4 @@ package org.opensearch.notifications.spi.model.destination
  */
 class ChimeDestination(
     url: String,
-) : WebhookDestination(url, "Chime")
+) : WebhookDestination(url, "chime")

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
@@ -17,4 +17,4 @@ package org.opensearch.notifications.spi.model.destination
 class CustomWebhookDestination(
     url: String,
     val headerParams: Map<String, String>,
-) : WebhookDestination(url, "Webhook")
+) : WebhookDestination(url, "webhook")

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
@@ -17,4 +17,4 @@ package org.opensearch.notifications.spi.model.destination
 class CustomWebhookDestination(
     url: String,
     val headerParams: Map<String, String>,
-) : WebhookDestination(url, "webhook")
+) : WebhookDestination(url, DestinationType.CUSTOMWEBHOOK)

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/DestinationType.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/DestinationType.kt
@@ -10,10 +10,9 @@
  */
 
 package org.opensearch.notifications.spi.model.destination
-
 /**
- * This class holds the contents of a Slack destination
+ * Supported notification destinations
  */
-class SlackDestination(
-    url: String,
-) : WebhookDestination(url, DestinationType.SLACK)
+enum class DestinationType {
+    CHIME, SLACK, CUSTOMWEBHOOK, SMTP, SES, SNS
+}

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
@@ -39,12 +39,12 @@ class EmailDestination(
     val method: String,
     val fromAddress: String,
     val recipient: String,
-    destinationType: String, // Smtp or Ses
+    destinationType: DestinationType, // smtp or ses
 ) : BaseDestination(destinationType) {
 
     init {
         when (destinationType) {
-            "smtp" -> {
+            DestinationType.SMTP -> {
                 require(!Strings.isNullOrEmpty(host)) { "Host name should be provided" }
                 require(port > 0) { "Port should be positive value" }
                 validateEmail(fromAddress)

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/EmailDestination.kt
@@ -44,13 +44,13 @@ class EmailDestination(
 
     init {
         when (destinationType) {
-            "Smtp" -> {
+            "smtp" -> {
                 require(!Strings.isNullOrEmpty(host)) { "Host name should be provided" }
                 require(port > 0) { "Port should be positive value" }
                 validateEmail(fromAddress)
                 validateEmail(recipient)
             }
-            // TODO Add Ses here
+            // TODO Add ses here
         }
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/SlackDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/SlackDestination.kt
@@ -16,4 +16,4 @@ package org.opensearch.notifications.spi.model.destination
  */
 class SlackDestination(
     url: String,
-) : WebhookDestination(url, "Slack")
+) : WebhookDestination(url, "slack")

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
@@ -22,7 +22,7 @@ import java.net.URISyntaxException
  */
 abstract class WebhookDestination(
     val url: String,
-    destinationType: String
+    destinationType: DestinationType
 ) : BaseDestination(destinationType) {
 
     init {

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
@@ -191,7 +191,6 @@ internal object PluginSettings {
         socketTimeout = (settings?.get(SOCKET_TIMEOUT_MILLISECONDS_KEY)?.toInt()) ?: DEFAULT_SOCKET_TIMEOUT_MILLISECONDS
         allowedConfigTypes = settings?.getAsList(ALLOWED_CONFIG_TYPE_KEY, null) ?: DEFAULT_ALLOWED_CONFIG_TYPES
 
-
         defaultSettings = mapOf(
             EMAIL_SIZE_LIMIT_KEY to emailSizeLimit.toString(DECIMAL_RADIX),
             EMAIL_MINIMUM_HEADER_LENGTH_KEY to emailMinimumHeaderLength.toString(DECIMAL_RADIX),
@@ -245,8 +244,6 @@ internal object PluginSettings {
         { it },
         NodeScope, Dynamic
     )
-
-
 
     /**
      * Returns list of additional settings available specific to this plugin.

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
@@ -1,0 +1,363 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ *  Modifications Copyright OpenSearch Contributors. See
+ *  GitHub history for details.
+ */
+
+package org.opensearch.notifications.spi.setting
+
+import org.opensearch.bootstrap.BootstrapInfo
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Setting.Property.Dynamic
+import org.opensearch.common.settings.Setting.Property.NodeScope
+import org.opensearch.common.settings.Settings
+import org.opensearch.notifications.spi.NotificationSpiPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.spi.NotificationSpiPlugin.Companion.PLUGIN_NAME
+import org.opensearch.notifications.spi.utils.logger
+import java.io.IOException
+import java.nio.file.Path
+
+internal object PluginSettings {
+    /**
+     * Settings Key prefix for this plugin.
+     */
+    private const val KEY_PREFIX = "opensearch.notifications.spi"
+
+    /**
+     * Settings Key prefix for Email.
+     */
+    private const val EMAIL_KEY_PREFIX = "$KEY_PREFIX.email"
+
+    /**
+     * Settings Key prefix for http connection.
+     */
+    private const val HTTP_CONNECTION_KEY_PREFIX = "$KEY_PREFIX.http"
+
+    /**
+     * Email size limit.
+     */
+    private const val EMAIL_SIZE_LIMIT_KEY = "$EMAIL_KEY_PREFIX.sizeLimit"
+
+    /**
+     * Email minimum header length.
+     */
+    private const val EMAIL_MINIMUM_HEADER_LENGTH_KEY = "$EMAIL_KEY_PREFIX.minimumHeaderLength"
+
+    /**
+     * Settings Key prefix for http connection.
+     */
+    private const val MAX_CONNECTIONS_KEY = "$HTTP_CONNECTION_KEY_PREFIX.maxConnections"
+
+    /**
+     * Settings Key prefix for max http connection per route.
+     */
+    private const val MAX_CONNECTIONS_PER_ROUTE_KEY = "$HTTP_CONNECTION_KEY_PREFIX.maxConnectionPerRoute"
+
+    /**
+     * Settings Key prefix for connection timeout in milliseconds
+     */
+    private const val CONNECTION_TIMEOUT_MILLISECONDS_KEY = "$HTTP_CONNECTION_KEY_PREFIX.connectionTimeout"
+
+    /**
+     * Settings Key prefix for socket timeout in milliseconds
+     */
+    private const val SOCKET_TIMEOUT_MILLISECONDS_KEY = "$HTTP_CONNECTION_KEY_PREFIX.socketTimeout"
+
+    /**
+     * Setting to choose allowed config types.
+     */
+    private const val ALLOWED_CONFIG_TYPE_KEY = "$KEY_PREFIX.allowedConfigTypes"
+
+    /**
+     * Default email size limit as 10MB.
+     */
+    private const val DEFAULT_EMAIL_SIZE_LIMIT = 10000000
+
+    /**
+     * Minimum email size limit as 10KB.
+     */
+    private const val MINIMUM_EMAIL_SIZE_LIMIT = 10000
+
+    /**
+     * Default value  for http connection.
+     */
+    private const val DEFAULT_MAX_CONNECTIONS = 60
+
+    /**
+     * Default value for max http connection per route.
+     */
+    private const val DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 20
+
+    /**
+     * Default value for connection timeout in milliseconds
+     */
+    private const val DEFAULT_CONNECTION_TIMEOUT_MILLISECONDS = 5000
+
+    /**
+     * Default value for socket timeout in milliseconds
+     */
+    private const val DEFAULT_SOCKET_TIMEOUT_MILLISECONDS = 50000
+
+    /**
+     * Default email header length. minimum value from 100 reference emails
+     */
+    private const val DEFAULT_MINIMUM_EMAIL_HEADER_LENGTH = 160
+
+    /**
+     * Default feature list
+     */
+    private val DEFAULT_ALLOWED_CONFIG_TYPES = listOf(
+        "slack",
+        "chime",
+        "custom_webhook",
+        "email",
+        "smtp_account",
+        "email_group"
+    )
+
+    /**
+     * list of allowed config types.
+     */
+    @Volatile
+    var allowedConfigTypes: List<String>
+
+    /**
+     * Email size limit setting
+     */
+    @Volatile
+    var emailSizeLimit: Int
+
+    /**
+     * Email minimum header length setting
+     */
+    @Volatile
+    var emailMinimumHeaderLength: Int
+
+    /**
+     * Http max connections
+     */
+    @Volatile
+    var maxConnections: Int
+
+    /**
+     * Http max connections per route
+     */
+    @Volatile
+    var maxConnectionsPerRoute: Int
+
+    /**
+     * Connection timeout
+     */
+    @Volatile
+    var connectionTimeout: Int
+
+    /**
+     * Socket timeout
+     */
+    @Volatile
+    var socketTimeout: Int
+
+    private const val DECIMAL_RADIX: Int = 10
+
+    private val log by logger(javaClass)
+    val defaultSettings: Map<String, String>
+
+    init {
+        var settings: Settings? = null
+        val configDirName = BootstrapInfo.getSystemProperties()?.get("opensearch.path.conf")?.toString()
+        if (configDirName != null) {
+            val defaultSettingYmlFile = Path.of(configDirName, PLUGIN_NAME, "notifications.yml")
+            try {
+                settings = Settings.builder().loadFromPath(defaultSettingYmlFile).build()
+            } catch (e: IOException) {
+                log.warn("$LOG_PREFIX:Failed to load ${defaultSettingYmlFile.toAbsolutePath()}:${e.message}")
+            }
+        }
+        // Initialize the settings values to default values
+        emailSizeLimit = (settings?.get(EMAIL_SIZE_LIMIT_KEY)?.toInt()) ?: DEFAULT_EMAIL_SIZE_LIMIT
+        emailMinimumHeaderLength = (settings?.get(EMAIL_MINIMUM_HEADER_LENGTH_KEY)?.toInt())
+            ?: DEFAULT_MINIMUM_EMAIL_HEADER_LENGTH
+        maxConnections = (settings?.get(MAX_CONNECTIONS_KEY)?.toInt()) ?: DEFAULT_MAX_CONNECTIONS
+        maxConnectionsPerRoute = (settings?.get(MAX_CONNECTIONS_PER_ROUTE_KEY)?.toInt())
+            ?: DEFAULT_MAX_CONNECTIONS_PER_ROUTE
+        connectionTimeout = (settings?.get(CONNECTION_TIMEOUT_MILLISECONDS_KEY)?.toInt())
+            ?: DEFAULT_CONNECTION_TIMEOUT_MILLISECONDS
+        socketTimeout = (settings?.get(SOCKET_TIMEOUT_MILLISECONDS_KEY)?.toInt()) ?: DEFAULT_SOCKET_TIMEOUT_MILLISECONDS
+        allowedConfigTypes = settings?.getAsList(ALLOWED_CONFIG_TYPE_KEY, null) ?: DEFAULT_ALLOWED_CONFIG_TYPES
+
+
+        defaultSettings = mapOf(
+            EMAIL_SIZE_LIMIT_KEY to emailSizeLimit.toString(DECIMAL_RADIX),
+            EMAIL_MINIMUM_HEADER_LENGTH_KEY to emailMinimumHeaderLength.toString(DECIMAL_RADIX),
+            MAX_CONNECTIONS_KEY to maxConnections.toString(DECIMAL_RADIX),
+            MAX_CONNECTIONS_PER_ROUTE_KEY to maxConnectionsPerRoute.toString(DECIMAL_RADIX),
+            CONNECTION_TIMEOUT_MILLISECONDS_KEY to connectionTimeout.toString(DECIMAL_RADIX),
+            SOCKET_TIMEOUT_MILLISECONDS_KEY to socketTimeout.toString(DECIMAL_RADIX)
+        )
+    }
+
+    private val EMAIL_SIZE_LIMIT: Setting<Int> = Setting.intSetting(
+        EMAIL_SIZE_LIMIT_KEY,
+        defaultSettings[EMAIL_SIZE_LIMIT_KEY]!!.toInt(),
+        MINIMUM_EMAIL_SIZE_LIMIT,
+        NodeScope, Dynamic
+    )
+
+    private val EMAIL_MINIMUM_HEADER_LENGTH: Setting<Int> = Setting.intSetting(
+        EMAIL_MINIMUM_HEADER_LENGTH_KEY,
+        defaultSettings[EMAIL_MINIMUM_HEADER_LENGTH_KEY]!!.toInt(),
+        NodeScope, Dynamic
+    )
+
+    private val MAX_CONNECTIONS: Setting<Int> = Setting.intSetting(
+        MAX_CONNECTIONS_KEY,
+        defaultSettings[MAX_CONNECTIONS_KEY]!!.toInt(),
+        NodeScope, Dynamic
+    )
+
+    private val MAX_CONNECTIONS_PER_ROUTE: Setting<Int> = Setting.intSetting(
+        MAX_CONNECTIONS_PER_ROUTE_KEY,
+        defaultSettings[MAX_CONNECTIONS_PER_ROUTE_KEY]!!.toInt(),
+        NodeScope, Dynamic
+    )
+
+    private val CONNECTION_TIMEOUT_MILLISECONDS: Setting<Int> = Setting.intSetting(
+        CONNECTION_TIMEOUT_MILLISECONDS_KEY,
+        defaultSettings[CONNECTION_TIMEOUT_MILLISECONDS_KEY]!!.toInt(),
+        NodeScope, Dynamic
+    )
+
+    private val SOCKET_TIMEOUT_MILLISECONDS: Setting<Int> = Setting.intSetting(
+        SOCKET_TIMEOUT_MILLISECONDS_KEY,
+        defaultSettings[SOCKET_TIMEOUT_MILLISECONDS_KEY]!!.toInt(),
+        NodeScope, Dynamic
+    )
+
+    private val ALLOWED_CONFIG_TYPES: Setting<List<String>> = Setting.listSetting(
+        ALLOWED_CONFIG_TYPE_KEY,
+        DEFAULT_ALLOWED_CONFIG_TYPES,
+        { it },
+        NodeScope, Dynamic
+    )
+
+
+
+    /**
+     * Returns list of additional settings available specific to this plugin.
+     *
+     * @return list of settings defined in this plugin
+     */
+    fun getAllSettings(): List<Setting<*>> {
+        return listOf(
+            EMAIL_SIZE_LIMIT,
+            EMAIL_MINIMUM_HEADER_LENGTH,
+            MAX_CONNECTIONS,
+            MAX_CONNECTIONS_PER_ROUTE,
+            CONNECTION_TIMEOUT_MILLISECONDS,
+            SOCKET_TIMEOUT_MILLISECONDS,
+            ALLOWED_CONFIG_TYPES
+        )
+    }
+    /**
+     * Update the setting variables to setting values from local settings
+     * @param clusterService cluster service instance
+     */
+    private fun updateSettingValuesFromLocal(clusterService: ClusterService) {
+        allowedConfigTypes = ALLOWED_CONFIG_TYPES.get(clusterService.settings)
+        emailSizeLimit = EMAIL_SIZE_LIMIT.get(clusterService.settings)
+        emailMinimumHeaderLength = EMAIL_MINIMUM_HEADER_LENGTH.get(clusterService.settings)
+        maxConnections = MAX_CONNECTIONS.get(clusterService.settings)
+        maxConnectionsPerRoute = MAX_CONNECTIONS_PER_ROUTE.get(clusterService.settings)
+        connectionTimeout = CONNECTION_TIMEOUT_MILLISECONDS.get(clusterService.settings)
+        socketTimeout = SOCKET_TIMEOUT_MILLISECONDS.get(clusterService.settings)
+    }
+
+    /**
+     * Update the setting variables to setting values from cluster settings
+     * @param clusterService cluster service instance
+     */
+    @Suppress("LongMethod")
+    private fun updateSettingValuesFromCluster(clusterService: ClusterService) {
+        val clusterEmailSizeLimit = clusterService.clusterSettings.get(EMAIL_SIZE_LIMIT)
+        if (clusterEmailSizeLimit != null) {
+            log.debug("$LOG_PREFIX:$EMAIL_SIZE_LIMIT_KEY -autoUpdatedTo-> $clusterEmailSizeLimit")
+            emailSizeLimit = clusterEmailSizeLimit
+        }
+        val clusterEmailMinimumHeaderLength = clusterService.clusterSettings.get(EMAIL_MINIMUM_HEADER_LENGTH)
+        if (clusterEmailMinimumHeaderLength != null) {
+            log.debug("$LOG_PREFIX:$EMAIL_MINIMUM_HEADER_LENGTH_KEY -autoUpdatedTo-> $clusterEmailMinimumHeaderLength")
+            emailMinimumHeaderLength = clusterEmailMinimumHeaderLength
+        }
+        val clusterMaxConnections = clusterService.clusterSettings.get(MAX_CONNECTIONS)
+        if (clusterMaxConnections != null) {
+            log.debug("$LOG_PREFIX:$MAX_CONNECTIONS_KEY -autoUpdatedTo-> $clusterMaxConnections")
+            maxConnections = clusterMaxConnections
+        }
+        val clusterMaxConnectionsPerRoute = clusterService.clusterSettings.get(MAX_CONNECTIONS_PER_ROUTE)
+        if (clusterMaxConnectionsPerRoute != null) {
+            log.debug("$LOG_PREFIX:$MAX_CONNECTIONS_PER_ROUTE_KEY -autoUpdatedTo-> $clusterMaxConnectionsPerRoute")
+            maxConnectionsPerRoute = clusterMaxConnectionsPerRoute
+        }
+        val clusterConnectionTimeout = clusterService.clusterSettings.get(CONNECTION_TIMEOUT_MILLISECONDS)
+        if (clusterConnectionTimeout != null) {
+            log.debug("$LOG_PREFIX:$CONNECTION_TIMEOUT_MILLISECONDS_KEY -autoUpdatedTo-> $clusterConnectionTimeout")
+            connectionTimeout = clusterConnectionTimeout
+        }
+        val clusterSocketTimeout = clusterService.clusterSettings.get(SOCKET_TIMEOUT_MILLISECONDS)
+        if (clusterSocketTimeout != null) {
+            log.debug("$LOG_PREFIX:$SOCKET_TIMEOUT_MILLISECONDS_KEY -autoUpdatedTo-> $clusterSocketTimeout")
+            socketTimeout = clusterSocketTimeout
+        }
+        val clusterallowedConfigTypes = clusterService.clusterSettings.get(ALLOWED_CONFIG_TYPES)
+        if (clusterallowedConfigTypes != null) {
+            log.debug("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -autoUpdatedTo-> $clusterallowedConfigTypes")
+            allowedConfigTypes = clusterallowedConfigTypes
+        }
+    }
+
+    /**
+     * adds Settings update listeners to all settings.
+     * @param clusterService cluster service instance
+     */
+    fun addSettingsUpdateConsumer(clusterService: ClusterService) {
+        updateSettingValuesFromLocal(clusterService)
+        // Update the variables to cluster setting values
+        // If the cluster is not yet started then we get default values again
+        updateSettingValuesFromCluster(clusterService)
+
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOWED_CONFIG_TYPES) {
+            allowedConfigTypes = it
+            log.info("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(EMAIL_SIZE_LIMIT) {
+            emailSizeLimit = it
+            log.info("$LOG_PREFIX:$EMAIL_SIZE_LIMIT_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(EMAIL_MINIMUM_HEADER_LENGTH) {
+            emailMinimumHeaderLength = it
+            log.info("$LOG_PREFIX:$EMAIL_MINIMUM_HEADER_LENGTH_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_CONNECTIONS) {
+            maxConnections = it
+            log.info("$LOG_PREFIX:$MAX_CONNECTIONS_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_CONNECTIONS_PER_ROUTE) {
+            maxConnectionsPerRoute = it
+            log.info("$LOG_PREFIX:$MAX_CONNECTIONS_PER_ROUTE_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(CONNECTION_TIMEOUT_MILLISECONDS) {
+            connectionTimeout = it
+            log.info("$LOG_PREFIX:$CONNECTION_TIMEOUT_MILLISECONDS_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(SOCKET_TIMEOUT_MILLISECONDS) {
+            socketTimeout = it
+            log.info("$LOG_PREFIX:$SOCKET_TIMEOUT_MILLISECONDS_KEY -updatedTo-> $it")
+        }
+    }
+}

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
@@ -41,6 +41,7 @@ import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
+import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.rest.RestStatus
 
 internal class ChimeDestinationTests {
@@ -50,7 +51,7 @@ internal class ChimeDestinationTests {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
 
         // The DestinationHttpClient replaces a null entity with "{}".
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "{}", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -65,7 +66,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.CHIME to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -86,7 +87,7 @@ internal class ChimeDestinationTests {
     @Throws(Exception::class)
     fun `test chime message empty entity response`() {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -100,7 +101,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.CHIME to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -122,7 +123,7 @@ internal class ChimeDestinationTests {
     fun `test chime message non-empty entity response`() {
         val responseContent = "It worked!"
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK, responseContent)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -136,7 +137,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.CHIME to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
@@ -65,7 +65,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -76,7 +76,7 @@ internal class ChimeDestinationTests {
         val destination = ChimeDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualChimeResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualChimeResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualChimeResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualChimeResponse.statusCode)
@@ -100,7 +100,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -111,7 +111,7 @@ internal class ChimeDestinationTests {
         val destination = ChimeDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualChimeResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualChimeResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualChimeResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualChimeResponse.statusCode)
@@ -136,7 +136,7 @@ internal class ChimeDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Chime" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("chime" to webhookDestinationFactory)
 
         val title = "test Chime"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -147,7 +147,7 @@ internal class ChimeDestinationTests {
         val destination = ChimeDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualChimeResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualChimeResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualChimeResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualChimeResponse.statusCode)

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
@@ -41,6 +41,7 @@ import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
+import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.rest.RestStatus
 
 internal class CustomWebhookDestinationTests {
@@ -50,7 +51,7 @@ internal class CustomWebhookDestinationTests {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
 
         // The DestinationHttpClient replaces a null entity with "{}".
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "{}", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -65,7 +66,9 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(
+            DestinationType.CUSTOMWEBHOOK to webhookDestinationFactory
+        )
 
         val title = "test custom webhook"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -86,7 +89,7 @@ internal class CustomWebhookDestinationTests {
     @Throws(Exception::class)
     fun `test custom webhook message empty entity response`() {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -100,7 +103,9 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(
+            DestinationType.CUSTOMWEBHOOK to webhookDestinationFactory
+        )
 
         val title = "test custom webhook"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -122,7 +127,7 @@ internal class CustomWebhookDestinationTests {
     fun `test custom webhook message non-empty entity response`() {
         val responseContent = "It worked!"
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK, responseContent)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -136,7 +141,9 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(
+            DestinationType.CUSTOMWEBHOOK to webhookDestinationFactory
+        )
 
         val title = "test custom webhook"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
@@ -65,7 +65,7 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
 
         val title = "test custom webhook"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -76,7 +76,7 @@ internal class CustomWebhookDestinationTests {
         val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"))
         val message = MessageContent(title, messageText)
 
-        val actualCustomWebhookResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualCustomWebhookResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualCustomWebhookResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualCustomWebhookResponse.statusCode)
@@ -100,7 +100,7 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
 
         val title = "test custom webhook"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -111,7 +111,7 @@ internal class CustomWebhookDestinationTests {
         val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"))
         val message = MessageContent(title, messageText)
 
-        val actualCustomWebhookResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualCustomWebhookResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualCustomWebhookResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualCustomWebhookResponse.statusCode)
@@ -136,7 +136,7 @@ internal class CustomWebhookDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Webhook" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("webhook" to webhookDestinationFactory)
 
         val title = "test custom webhook"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -147,7 +147,7 @@ internal class CustomWebhookDestinationTests {
         val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"))
         val message = MessageContent(title, messageText)
 
-        val actualCustomWebhookResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualCustomWebhookResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualCustomWebhookResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualCustomWebhookResponse.statusCode)

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
@@ -20,6 +20,7 @@ import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.factory.SmtpEmailDestinationFactory
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.notifications.spi.model.destination.EmailDestination
 import org.opensearch.rest.RestStatus
 import javax.mail.Message
@@ -29,19 +30,19 @@ internal class EmailDestinationTests {
     @Test
     @Throws(Exception::class)
     fun testSmtpEmailMessage() {
-        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK, "Success")
+        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK.status, "Success")
         val emailClient: DestinationEmailClient = EasyMock.partialMockBuilder(DestinationEmailClient::class.java)
             .addMockedMethod("sendMessage").createMock()
         emailClient.sendMessage(EasyMock.anyObject(Message::class.java))
         val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("smtp" to smtpEmailDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.SMTP to smtpEmailDestinationFactory)
 
         val subject = "Test SMTP Email subject"
         val messageText = "{Message gughjhjlkh Body emoji test: :) :+1: " +
             "link test: http://sample.com email test: marymajor@example.com All member callout: " +
             "@All All Present member callout: @Present}"
         val message = MessageContent(subject, messageText)
-        val destination = EmailDestination("abc", 465, "ssl", "test@abc.com", "to@abc.com", "smtp")
+        val destination = EmailDestination("abc", 465, "ssl", "test@abc.com", "to@abc.com", DestinationType.SMTP)
 
         val actualEmailResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
         assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
@@ -52,7 +53,7 @@ internal class EmailDestinationTests {
     @Throws(Exception::class)
     fun testSmtpFailingEmailMessage() {
         val expectedEmailResponse = DestinationMessageResponse(
-            RestStatus.FAILED_DEPENDENCY,
+            RestStatus.FAILED_DEPENDENCY.status,
             "Couldn't connect to host, port: localhost, 55555; timeout -1"
         )
         val emailClient: DestinationEmailClient = EasyMock.partialMockBuilder(DestinationEmailClient::class.java)
@@ -62,14 +63,21 @@ internal class EmailDestinationTests {
             .andThrow(MessagingException("Couldn't connect to host, port: localhost, 55555; timeout -1"))
         EasyMock.replay(emailClient)
         val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("smtp" to smtpEmailDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.SMTP to smtpEmailDestinationFactory)
 
         val subject = "Test SMTP Email subject"
         val messageText = "{Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
             "link test: http://sample.com email test: marymajor@example.com All member callout: " +
             "@All All Present member callout: @Present}"
         val message = MessageContent(subject, messageText)
-        val destination = EmailDestination("localhost", 55555, "none", "test@abc.com", "to@abc.com", "smtp")
+        val destination = EmailDestination(
+            "localhost",
+            55555,
+            "none",
+            "test@abc.com",
+            "to@abc.com",
+            DestinationType.SMTP
+        )
 
         val actualEmailResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
         EasyMock.verify(emailClient)
@@ -80,7 +88,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testHostMissingEmailDestination() {
         try {
-            EmailDestination("", 465, "ssl", "from@test.com", "to@test.com", "smtp")
+            EmailDestination("", 465, "ssl", "from@test.com", "to@test.com", DestinationType.SMTP)
         } catch (exception: Exception) {
             Assert.assertEquals("Host name should be provided", exception.message)
             throw exception
@@ -90,7 +98,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidPortEmailDestination() {
         try {
-            EmailDestination("localhost", -1, "ssl", "from@test.com", "to@test.com", "smtp")
+            EmailDestination("localhost", -1, "ssl", "from@test.com", "to@test.com", DestinationType.SMTP)
         } catch (exception: Exception) {
             Assert.assertEquals("Port should be positive value", exception.message)
             throw exception
@@ -100,7 +108,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testMissingFromOrRecipientEmailDestination() {
         try {
-            EmailDestination("localhost", 465, "ssl", "", "to@test.com", "smtp")
+            EmailDestination("localhost", 465, "ssl", "", "to@test.com", DestinationType.SMTP)
         } catch (exception: Exception) {
             Assert.assertEquals("FromAddress and recipient should be provided", exception.message)
             throw exception

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/EmailDestinationTests.kt
@@ -34,16 +34,16 @@ internal class EmailDestinationTests {
             .addMockedMethod("sendMessage").createMock()
         emailClient.sendMessage(EasyMock.anyObject(Message::class.java))
         val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Smtp" to smtpEmailDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("smtp" to smtpEmailDestinationFactory)
 
         val subject = "Test SMTP Email subject"
         val messageText = "{Message gughjhjlkh Body emoji test: :) :+1: " +
             "link test: http://sample.com email test: marymajor@example.com All member callout: " +
             "@All All Present member callout: @Present}"
         val message = MessageContent(subject, messageText)
-        val destination = EmailDestination("abc", 465, "ssl", "test@abc.com", "to@abc.com", "Smtp")
+        val destination = EmailDestination("abc", 465, "ssl", "test@abc.com", "to@abc.com", "smtp")
 
-        val actualEmailResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualEmailResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
         assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
         assertEquals(expectedEmailResponse.statusText, actualEmailResponse.statusText)
     }
@@ -62,16 +62,16 @@ internal class EmailDestinationTests {
             .andThrow(MessagingException("Couldn't connect to host, port: localhost, 55555; timeout -1"))
         EasyMock.replay(emailClient)
         val smtpEmailDestinationFactory = SmtpEmailDestinationFactory(emailClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Smtp" to smtpEmailDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("smtp" to smtpEmailDestinationFactory)
 
         val subject = "Test SMTP Email subject"
         val messageText = "{Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
             "link test: http://sample.com email test: marymajor@example.com All member callout: " +
             "@All All Present member callout: @Present}"
         val message = MessageContent(subject, messageText)
-        val destination = EmailDestination("localhost", 55555, "none", "test@abc.com", "to@abc.com", "Smtp")
+        val destination = EmailDestination("localhost", 55555, "none", "test@abc.com", "to@abc.com", "smtp")
 
-        val actualEmailResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualEmailResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
         EasyMock.verify(emailClient)
         assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
         assertEquals("sendEmail Error, status:${expectedEmailResponse.statusText}", actualEmailResponse.statusText)
@@ -80,7 +80,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testHostMissingEmailDestination() {
         try {
-            EmailDestination("", 465, "ssl", "from@test.com", "to@test.com", "Smtp")
+            EmailDestination("", 465, "ssl", "from@test.com", "to@test.com", "smtp")
         } catch (exception: Exception) {
             Assert.assertEquals("Host name should be provided", exception.message)
             throw exception
@@ -90,7 +90,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidPortEmailDestination() {
         try {
-            EmailDestination("localhost", -1, "ssl", "from@test.com", "to@test.com", "Smtp")
+            EmailDestination("localhost", -1, "ssl", "from@test.com", "to@test.com", "smtp")
         } catch (exception: Exception) {
             Assert.assertEquals("Port should be positive value", exception.message)
             throw exception
@@ -100,7 +100,7 @@ internal class EmailDestinationTests {
     @Test(expected = IllegalArgumentException::class)
     fun testMissingFromOrRecipientEmailDestination() {
         try {
-            EmailDestination("localhost", 465, "ssl", "", "to@test.com", "Smtp")
+            EmailDestination("localhost", 465, "ssl", "", "to@test.com", "smtp")
         } catch (exception: Exception) {
             Assert.assertEquals("FromAddress and recipient should be provided", exception.message)
             throw exception

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
@@ -40,6 +40,7 @@ import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.notifications.spi.model.destination.SlackDestination
 import org.opensearch.rest.RestStatus
 
@@ -50,7 +51,7 @@ internal class SlackDestinationTests {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
 
         // The DestinationHttpClient replaces a null entity with "{}".
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "{}", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -65,7 +66,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.SLACK to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -86,7 +87,7 @@ internal class SlackDestinationTests {
     @Throws(Exception::class)
     fun `test Slack message empty entity response`() {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(statusText = "", statusCode = RestStatus.OK)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "")
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -100,7 +101,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.SLACK to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -122,7 +123,7 @@ internal class SlackDestinationTests {
     fun `test Slack message non-empty entity response`() {
         val responseContent = "It worked!"
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK, responseContent)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
 
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
@@ -136,7 +137,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf(DestinationType.SLACK to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
@@ -65,7 +65,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -76,7 +76,7 @@ internal class SlackDestinationTests {
         val destination = SlackDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualSlackResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualSlackResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualSlackResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualSlackResponse.statusCode)
@@ -100,7 +100,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -111,7 +111,7 @@ internal class SlackDestinationTests {
         val destination = SlackDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualSlackResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualSlackResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualSlackResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualSlackResponse.statusCode)
@@ -136,7 +136,7 @@ internal class SlackDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationFactory = WebhookDestinationFactory(httpClient)
-        DestinationFactoryProvider.destinationFactoryMap = mapOf("Slack" to webhookDestinationFactory)
+        DestinationFactoryProvider.destinationFactoryMap = mapOf("slack" to webhookDestinationFactory)
 
         val title = "test Slack"
         val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
@@ -147,7 +147,7 @@ internal class SlackDestinationTests {
         val destination = SlackDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualSlackResponse: DestinationMessageResponse = Notification.sendMessage(destination, message)
+        val actualSlackResponse: DestinationMessageResponse = NotificationSpi.sendMessage(destination, message)
 
         assertEquals(expectedWebhookResponse.statusText, actualSlackResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualSlackResponse.statusCode)

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/integTest/SmtpEmailIT.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/integTest/SmtpEmailIT.kt
@@ -12,7 +12,7 @@
 package org.opensearch.notifications.spi.integTest
 
 import org.junit.After
-import org.opensearch.notifications.spi.Notification
+import org.opensearch.notifications.spi.NotificationSpi
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.EmailDestination
 import org.opensearch.rest.RestStatus
@@ -34,11 +34,11 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
         smtpServer.resetServer()
     }
 
-    fun `test send email to one recipient over Smtp server`() {
+    fun `test send email to one recipient over smtp server`() {
         val emailDestination =
-            EmailDestination("localhost", smtpPort, "none", "from@email.com", "test@localhost.com", "Smtp")
+            EmailDestination("localhost", smtpPort, "none", "from@email.com", "test@localhost.com", "smtp")
         val message = MessageContent(
-            "Test Smtp email title",
+            "Test smtp email title",
             "Description for notification in text",
             "Description for notification in json encode html format",
             "opensearch.data",
@@ -46,16 +46,16 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
             "VGVzdCBtZXNzYWdlCgo=",
             "application/octet-stream",
         )
-        val response = Notification.sendMessage(emailDestination, message)
+        val response = NotificationSpi.sendMessage(emailDestination, message)
         assertEquals("Success", response.statusText)
         assertEquals(RestStatus.OK, response.statusCode)
     }
 
     fun `test send email with non-available host`() {
         val emailDestination =
-            EmailDestination("invalidHost", smtpPort, "none", "from@email.com", "test@localhost.com", "Smtp")
+            EmailDestination("invalidHost", smtpPort, "none", "from@email.com", "test@localhost.com", "smtp")
         val message = MessageContent(
-            "Test Smtp email title",
+            "Test smtp email title",
             "Description for notification in text",
             "Description for notification in json encode html format",
             "opensearch.data",
@@ -63,7 +63,7 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
             "VGVzdCBtZXNzYWdlCgo=",
             "application/octet-stream",
         )
-        val response = Notification.sendMessage(emailDestination, message)
+        val response = NotificationSpi.sendMessage(emailDestination, message)
         assertEquals(
             "sendEmail Error, status:Couldn't connect to host, port: invalidHost, $smtpPort; timeout -1",
             response.statusText

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/integTest/SmtpEmailIT.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/integTest/SmtpEmailIT.kt
@@ -14,6 +14,7 @@ package org.opensearch.notifications.spi.integTest
 import org.junit.After
 import org.opensearch.notifications.spi.NotificationSpi
 import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.notifications.spi.model.destination.EmailDestination
 import org.opensearch.rest.RestStatus
 import org.opensearch.test.rest.OpenSearchRestTestCase
@@ -35,8 +36,14 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
     }
 
     fun `test send email to one recipient over smtp server`() {
-        val emailDestination =
-            EmailDestination("localhost", smtpPort, "none", "from@email.com", "test@localhost.com", "smtp")
+        val emailDestination = EmailDestination(
+            "localhost",
+            smtpPort,
+            "none",
+            "from@email.com",
+            "test@localhost.com",
+            DestinationType.SMTP
+        )
         val message = MessageContent(
             "Test smtp email title",
             "Description for notification in text",
@@ -48,12 +55,18 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
         )
         val response = NotificationSpi.sendMessage(emailDestination, message)
         assertEquals("Success", response.statusText)
-        assertEquals(RestStatus.OK, response.statusCode)
+        assertEquals(RestStatus.OK.status, response.statusCode)
     }
 
     fun `test send email with non-available host`() {
-        val emailDestination =
-            EmailDestination("invalidHost", smtpPort, "none", "from@email.com", "test@localhost.com", "smtp")
+        val emailDestination = EmailDestination(
+            "invalidHost",
+            smtpPort,
+            "none",
+            "from@email.com",
+            "test@localhost.com",
+            DestinationType.SMTP
+        )
         val message = MessageContent(
             "Test smtp email title",
             "Description for notification in text",
@@ -68,6 +81,6 @@ internal class SmtpEmailIT : OpenSearchRestTestCase() {
             "sendEmail Error, status:Couldn't connect to host, port: invalidHost, $smtpPort; timeout -1",
             response.statusText
         )
-        assertEquals(RestStatus.SERVICE_UNAVAILABLE, response.statusCode)
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE.status, response.statusCode)
     }
 }

--- a/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -90,7 +90,7 @@ internal class NotificationPlugin : ActionPlugin, Plugin() {
 
         const val PLUGIN_NAME = "opensearch-notifications"
         const val LOG_PREFIX = "notifications"
-        const val PLUGIN_BASE_URI = "/_opensearch/_notifications"
+        const val PLUGIN_BASE_URI = "/_plugins/_notifications"
     }
 
     /**

--- a/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
@@ -36,8 +36,8 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.GetPluginFeaturesRequest
 import org.opensearch.commons.notifications.action.GetPluginFeaturesResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
-import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.notifications.spi.NotificationSpi
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 
@@ -78,20 +78,11 @@ internal class GetPluginFeaturesAction @Inject constructor(
         request: GetPluginFeaturesRequest,
         user: User?
     ): GetPluginFeaturesResponse {
-        // TODO: #130 Integrate with SPI to return features from config
+        val allowedConfigTypes = NotificationSpi.getAllowedConfigTypes()
+        val pluginFeatures = NotificationSpi.getPluginFeatures()
         return GetPluginFeaturesResponse(
-            listOf(
-                ConfigType.SLACK.tag,
-                ConfigType.CHIME.tag,
-                ConfigType.WEBHOOK.tag,
-                ConfigType.EMAIL.tag,
-                ConfigType.SMTP_ACCOUNT.tag,
-                ConfigType.EMAIL_GROUP.tag
-            ),
-            mapOf(
-                Pair("tooltip_support", "true"),
-                Pair("email_size_limit", "10000000")
-            )
+            allowedConfigTypes,
+            pluginFeatures
         )
     }
 }

--- a/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -206,7 +206,7 @@ object SendMessageActionHelper {
     private fun sendSlackMessage(slack: Slack, message: MessageContent, eventStatus: EventStatus): EventStatus {
         val destination = SlackDestination(slack.url)
         val status = sendMessageThroughSpi(destination, message)
-        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.name, status.statusText))
+        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
 
     /**
@@ -215,7 +215,7 @@ object SendMessageActionHelper {
     private fun sendChimeMessage(chime: Chime, message: MessageContent, eventStatus: EventStatus): EventStatus {
         val destination = ChimeDestination(chime.url)
         val status = sendMessageThroughSpi(destination, message)
-        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.name, status.statusText))
+        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
 
     /**
@@ -224,7 +224,7 @@ object SendMessageActionHelper {
     private fun sendWebhookMessage(webhook: Webhook, message: MessageContent, eventStatus: EventStatus): EventStatus {
         val destination = CustomWebhookDestination(webhook.url, webhook.headerParams)
         val status = sendMessageThroughSpi(destination, message)
-        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.name, status.statusText))
+        return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
 
     /**
@@ -294,7 +294,7 @@ object SendMessageActionHelper {
             status
         } catch (exception: Exception) {
             log.warn("sendMessage Exception:$exception")
-            DestinationMessageResponse(RestStatus.FAILED_DEPENDENCY, "Failed to send notification")
+            DestinationMessageResponse(RestStatus.FAILED_DEPENDENCY.status, "Failed to send notification")
         }
     }
 

--- a/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -38,7 +38,7 @@ import org.opensearch.notifications.model.DocMetadata
 import org.opensearch.notifications.model.NotificationConfigDocInfo
 import org.opensearch.notifications.model.NotificationEventDoc
 import org.opensearch.notifications.security.UserAccess
-import org.opensearch.notifications.spi.Notification
+import org.opensearch.notifications.spi.NotificationSpi
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.BaseDestination
@@ -289,7 +289,7 @@ object SendMessageActionHelper {
         message: MessageContent
     ): DestinationMessageResponse {
         return try {
-            val status = Notification.sendMessage(destination, message)
+            val status = NotificationSpi.sendMessage(destination, message)
             log.info("$LOG_PREFIX:sendMessage:statusCode=${status.statusCode}, statusText=${status.statusText}")
             status
         } catch (exception: Exception) {

--- a/notifications/src/test/kotlin/org/opensearch/notifications/resthandler/SendMessageRestHandlerTests.kt
+++ b/notifications/src/test/kotlin/org/opensearch/notifications/resthandler/SendMessageRestHandlerTests.kt
@@ -46,7 +46,7 @@ internal class SendMessageRestHandlerTests : OpenSearchTestCase() {
         val routes = restHandler.routes()
         val actualRouteSize = routes.size
         val actualRoute = routes[0]
-        val expectedRoute = RestHandler.Route(POST, "/_opensearch/_notifications/send")
+        val expectedRoute = RestHandler.Route(POST, "/_plugins/_notifications/send")
         assertEquals(1, actualRouteSize)
         assertEquals(expectedRoute.method, actualRoute.method)
         assertEquals(expectedRoute.path, actualRoute.path)


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
- Make SPI a dummy plugin in order to load configuration 
- Add interface in SPI to expose `plugin_feaures` and `config Types`
- Add `DestinationType` enum in SPI
- Modify `statusCode` in `DestinationResponse` to Int type

### Issues Resolved
#222 
#221 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
