### PR TITLE
add method type to custom webhook handler in SPI

### DIFF
--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
@@ -121,9 +121,10 @@ class DestinationHttpClient {
 
     @Throws(Exception::class)
     private fun getHttpResponse(destination: WebhookDestination, message: MessageContent): CloseableHttpResponse {
-        val httpRequest = HttpPost(destination.url)
+        var httpRequest: HttpRequestBase = HttpPost(destination.url)
 
         if (destination is CustomWebhookDestination) {
+            httpRequest = constructHttpRequest(destination.method)
             if (destination.headerParams.isEmpty()) {
                 // set default header
                 httpRequest.setHeader("Content-type", "application/json")
@@ -138,13 +139,14 @@ class DestinationHttpClient {
         return httpClient.execute(httpRequest)
     }
 
-    @SuppressWarnings("UnusedPrivateMember")
     private fun constructHttpRequest(method: String): HttpRequestBase {
         return when (method) {
-            "POST" -> HttpPost()
-            "PUT" -> HttpPut()
-            "PATCH" -> HttpPatch()
-            else -> throw IllegalArgumentException("Invalid method supplied")
+            HttpPost.METHOD_NAME -> HttpPost()
+            HttpPut.METHOD_NAME -> HttpPut()
+            HttpPatch.METHOD_NAME -> HttpPatch()
+            else -> throw IllegalArgumentException(
+                "Invalid or empty method supplied. Only POST, PUT and PATCH are allowed"
+            )
         }
     }
 

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/CustomWebhookDestination.kt
@@ -11,10 +11,18 @@
 
 package org.opensearch.notifications.spi.model.destination
 
+import org.opensearch.notifications.spi.utils.validateMethod
+
 /**
  * This class holds the contents of a custom webhook destination
  */
 class CustomWebhookDestination(
     url: String,
     val headerParams: Map<String, String>,
-) : WebhookDestination(url, DestinationType.CUSTOMWEBHOOK)
+    val method: String
+) : WebhookDestination(url, DestinationType.CUSTOMWEBHOOK) {
+
+    init {
+        validateMethod(method)
+    }
+}

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
@@ -12,7 +12,6 @@
 package org.opensearch.notifications.spi.model.destination
 
 import org.apache.http.client.utils.URIBuilder
-import org.opensearch.common.Strings
 import org.opensearch.notifications.spi.utils.validateUrl
 import java.net.URI
 import java.net.URISyntaxException
@@ -26,7 +25,6 @@ abstract class WebhookDestination(
 ) : BaseDestination(destinationType) {
 
     init {
-        require(!Strings.isNullOrEmpty(url)) { "url is invalid or empty" }
         validateUrl(url)
     }
 

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
@@ -27,10 +27,14 @@
 
 package org.opensearch.notifications.spi.utils
 
+import org.apache.http.client.methods.HttpPatch
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.client.methods.HttpPut
 import org.opensearch.common.Strings
 import java.net.URL
 
 fun validateUrl(urlString: String) {
+    require(!Strings.isNullOrEmpty(urlString)) { "url is null or empty" }
     require(isValidUrl(urlString)) { "Invalid URL or unsupported" }
     val url = URL(urlString)
     require("https" == url.protocol) // Support only HTTPS. HTTP and other protocols not supported
@@ -65,4 +69,12 @@ fun isValidEmail(email: String): Boolean {
         RegexOption.IGNORE_CASE
     )
     return validEmailPattern.matches(email)
+}
+
+fun validateMethod(method: String) {
+    require(!Strings.isNullOrEmpty(method)) { "Method is null or empty" }
+    val validMethods = listOf(HttpPost.METHOD_NAME, HttpPut.METHOD_NAME, HttpPatch.METHOD_NAME)
+    require(
+        method.findAnyOf(validMethods) != null
+    ) { "Invalid method supplied. Only POST, PUT and PATCH are allowed" }
 }

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
@@ -35,6 +35,7 @@ import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 import org.opensearch.notifications.spi.client.DestinationHttpClient
 import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
@@ -43,6 +44,7 @@ import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
 import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.rest.RestStatus
+import java.net.MalformedURLException
 
 internal class ChimeDestinationTests {
     @Test
@@ -159,8 +161,15 @@ internal class ChimeDestinationTests {
         try {
             ChimeDestination("")
         } catch (ex: Exception) {
-            assertEquals("url is invalid or empty", ex.message)
+            assertEquals("url is null or empty", ex.message)
             throw ex
+        }
+    }
+
+    @Test
+    fun testUrlInvalidMessage() {
+        assertThrows<MalformedURLException> {
+            ChimeDestination("invalidUrl")
         }
     }
 

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
@@ -35,14 +35,17 @@ import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 import org.opensearch.notifications.spi.client.DestinationHttpClient
 import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.ChimeDestination
 import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.notifications.spi.model.destination.SlackDestination
 import org.opensearch.rest.RestStatus
+import java.net.MalformedURLException
 
 internal class SlackDestinationTests {
     @Test
@@ -159,8 +162,15 @@ internal class SlackDestinationTests {
         try {
             SlackDestination("")
         } catch (ex: Exception) {
-            assertEquals("url is invalid or empty", ex.message)
+            assertEquals("url is null or empty", ex.message)
             throw ex
+        }
+    }
+
+    @Test
+    fun testUrlInvalidMessage() {
+        assertThrows<MalformedURLException> {
+            ChimeDestination("invalidUrl")
         }
     }
 }

--- a/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -222,7 +222,7 @@ object SendMessageActionHelper {
      * send message to custom webhook destination
      */
     private fun sendWebhookMessage(webhook: Webhook, message: MessageContent, eventStatus: EventStatus): EventStatus {
-        val destination = CustomWebhookDestination(webhook.url, webhook.headerParams)
+        val destination = CustomWebhookDestination(webhook.url, webhook.headerParams, "POST")
         val status = sendMessageThroughSpi(destination, message)
         return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
- add method in Custom webhook data model
- add logic in DestinationHttpClient to handle different method types for custom webook

### Issues Resolved
SPI part of #219 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
