### PR TITLE
Update backend API path for UI, refactors

### DIFF
--- a/dashboards-notifications/README.md
+++ b/dashboards-notifications/README.md
@@ -4,7 +4,7 @@ Dashboards Notifications plugin provides an interface that helps users to manage
 
 ## Documentation
 
-Please see our technical [documentation](https://docs-beta.opensearch.org/) to learn more about its features.
+Please see our technical [documentation](https://opensearch.org/docs/) to learn more about its features.
 
 ## Setup
 

--- a/dashboards-notifications/common/index.ts
+++ b/dashboards-notifications/common/index.ts
@@ -44,7 +44,7 @@ export const NODE_API = Object.freeze({
 });
 
 // TODO change to _plugins when backend updates
-const OPENSEARCH_API_BASE_PATH = '/_opensearch/_notifications';
+const OPENSEARCH_API_BASE_PATH = '/_plugins/_notifications';
 export const OPENSEARCH_API = Object.freeze({
   CONFIGS: `${OPENSEARCH_API_BASE_PATH}/configs`,
   EVENTS: `${OPENSEARCH_API_BASE_PATH}/events`,

--- a/dashboards-notifications/public/pages/Main/Main.tsx
+++ b/dashboards-notifications/public/pages/Main/Main.tsx
@@ -24,13 +24,7 @@
  * permissions and limitations under the License.
  */
 
-import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageSideBar,
-  EuiSideNav,
-  SortDirection,
-} from '@elastic/eui';
+import { EuiPage, EuiPageBody, EuiPageSideBar, EuiSideNav } from '@elastic/eui';
 import React, { Component, createContext } from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { CoreStart } from '../../../../../src/core/public';
@@ -62,7 +56,6 @@ enum Pathname {
 interface MainProps extends RouteComponentProps {}
 
 export interface MainState {
-  isChannelConfigured: boolean;
   availableFeatures: Partial<typeof CHANNEL_TYPE>;
 }
 
@@ -74,30 +67,14 @@ export default class Main extends Component<MainProps, MainState> {
   constructor(props: MainProps) {
     super(props);
     this.state = {
-      isChannelConfigured: true,
       availableFeatures: CHANNEL_TYPE,
     };
   }
 
   async componentDidMount() {
-    const availableFeatures = await this.context.notificationService.getAvailableFeatures();
+    const availableFeatures =
+      await this.context.notificationService.getAvailableFeatures();
     if (availableFeatures != null) this.setState({ availableFeatures });
-    try {
-      const isChannelConfigured = await this.context.notificationService.getChannels(
-        {
-          config_type: Object.keys(CHANNEL_TYPE),
-          from_index: 0,
-          max_items: 1,
-          sort_field: 'name',
-          sort_order: SortDirection.ASC,
-        }
-      );
-      if (!isChannelConfigured?.total) {
-        this.setState({ isChannelConfigured: false });
-      }
-    } catch (error) {
-      this.setState({ isChannelConfigured: false });
-    }
   }
 
   render() {

--- a/dashboards-notifications/public/pages/Notifications/__tests__/__snapshots__/TableFlyout.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Notifications/__tests__/__snapshots__/TableFlyout.test.tsx.snap
@@ -372,7 +372,12 @@ exports[`<TableFlyout /> spec renders the component 1`] = `
                     <dd
                       class="euiDescriptionList__description"
                     >
-                      failed
+                      <div
+                        class="euiText euiText--small"
+                        style="line-break: anywhere;"
+                      >
+                        failed
+                      </div>
                     </dd>
                   </dl>
                 </div>

--- a/dashboards-notifications/public/pages/Notifications/components/NotificationsTable/Flyout/ChannelCard.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/NotificationsTable/Flyout/ChannelCard.tsx
@@ -110,7 +110,9 @@ export function ChannelCard(props: ChannelCardProps) {
         {!isStatusCodeSuccess(props.channel.delivery_status.status_code) &&
           renderList(
             'Error details',
-            props.channel.delivery_status.status_text
+            <EuiText style={{ lineBreak: 'anywhere' }} size="s">
+              {props.channel.delivery_status.status_text}
+            </EuiText>
           )}
       </EuiCard>
     </>

--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -1,4 +1,3 @@
-import { SortDirection } from '@elastic/eui';
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,6 +24,7 @@ import { SortDirection } from '@elastic/eui';
  * permissions and limitations under the License.
  */
 
+import { SortDirection } from '@elastic/eui';
 import { HttpFetchQuery, HttpSetup } from '../../../../src/core/public';
 import { NODE_API } from '../../common';
 import {
@@ -134,7 +134,6 @@ export default class NotificationService {
       (id) => (channel.email!.email_group_id_map![id] = idMap[id])
     );
 
-    console.log('channel:', channel);
     return channel;
   };
 

--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -1,3 +1,4 @@
+import { SortDirection } from '@elastic/eui';
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -108,27 +109,32 @@ export default class NotificationService {
     channel: ChannelItemType
   ): Promise<ChannelItemType> => {
     if (!channel.email) return channel;
-    channel.email.email_account_name = await this.getChannel(
-      channel.email.email_account_id
-    ).then((channel) => channel.name);
 
-    channel.email.email_group_id_map = {};
-    await channel.email.email_group_id_list
-      .map((id) => () =>
-        this.getChannel(id).then((channel) => ({ id, name: channel.name }))
-      )
-      .reduce(
-        (prev, curr) =>
-          prev.then(() =>
-            curr().then(
-              (response) =>
-                (channel.email!.email_group_id_map![response.id] =
-                  response.name)
-            )
-          ),
-        Promise.resolve() as any
+    const idMap: { [id: string]: string } = {};
+    const ids = [
+      channel.email.email_account_id,
+      ...channel.email.email_group_id_list,
+    ];
+    await this.getConfigs({
+      from_index: 0,
+      max_items: ids.length,
+      config_id_list: ids,
+      sort_order: SortDirection.ASC,
+      sort_field: 'name',
+      config_type: ['smtp_account', 'email_group'],
+    }).then((response) => {
+      response.config_list.map(
+        (config) => (idMap[config.config_id] = config.config.name)
       );
+    });
 
+    channel.email.email_account_name = idMap[channel.email.email_account_id];
+    channel.email.email_group_id_map = {};
+    channel.email.email_group_id_list.map(
+      (id) => (channel.email!.email_group_id_map![id] = idMap[id])
+    );
+
+    console.log('channel:', channel);
     return channel;
   };
 

--- a/dashboards-notifications/public/utils/constants.ts
+++ b/dashboards-notifications/public/utils/constants.ts
@@ -26,10 +26,9 @@
 
 export const DOCUMENTATION_LINK = '';
 export const ALERTING_DOCUMENTATION_LINK =
-  'https://docs-beta.opensearch.org/docs/alerting/monitors/#authenticate-sender-account';
+  'https://opensearch.org/docs/monitoring-plugins/alerting/monitors/#authenticate-sender-account';
 
 export const ROUTES = Object.freeze({
-  // notification
   NOTIFICATIONS: '/notifications',
   CHANNELS: '/channels',
   CHANNEL_DETAILS: '/channel-details',

--- a/dashboards-notifications/server/routes/configRoutes.ts
+++ b/dashboards-notifications/server/routes/configRoutes.ts
@@ -36,12 +36,16 @@ export function configRoutes(router: IRouter) {
           is_enabled: schema.maybe(schema.boolean()),
           sort_field: schema.string(),
           sort_order: schema.string(),
+          config_id_list: schema.maybe(
+            schema.oneOf([schema.arrayOf(schema.string()), schema.string()])
+          ),
         }),
       },
     },
     async (context, request, response) => {
       const config_type = joinRequestParams(request.query.config_type);
       const feature_list = joinRequestParams(request.query.feature_list);
+      const config_id_list = joinRequestParams(request.query.config_id_list);
       const query = request.query.query;
       // @ts-ignore
       const client: ILegacyScopedClusterClient = context.notificationsContext.notificationsClient.asScoped(
@@ -59,6 +63,7 @@ export function configRoutes(router: IRouter) {
             config_type,
             ...(feature_list && { feature_list }),
             ...(query && { query }),
+            ...(config_id_list && { config_id_list }),
           }
         );
         return response.ok({ body: resp });

--- a/dashboards-notifications/test/mocks/serviceMock.ts
+++ b/dashboards-notifications/test/mocks/serviceMock.ts
@@ -54,7 +54,6 @@ const notificationServiceMock = {
 };
 
 const mainStateMock: MainState = {
-  isChannelConfigured: true,
   availableFeatures: CHANNEL_TYPE,
 };
 


### PR DESCRIPTION
### Description
- rename backend API from `_opensearch` to `_plugins`
- use `config_id_list` to query email sender/group names by configId in 1 request instead of chaining requests
- move detect channel existence logic to dashboard component so no need to refresh for updates
- fix docs links

Not much change to tests because behavior didn't change much

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
