### PR TITLE
Fix parsing webhook message content to request body

### DIFF
--- a/notifications/spi/build.gradle
+++ b/notifications/spi/build.gradle
@@ -96,6 +96,7 @@ allOpen {
 }
 
 test {
+    useJUnitPlatform()
     doFirst {
         // reverse operation of https://github.com/elastic/elasticsearch/blob/7.6/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy#L736-L743
         // to fix the classpath for unit tests
@@ -138,6 +139,7 @@ dependencies {
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',
+            "org.junit.jupiter:junit-jupiter-params:5.6.2",
             "org.easymock:easymock:4.0.1",
             "org.apache.logging.log4j:log4j-core:${versions.log4j}",
             "org.opensearch.test:framework:${opensearch_version}",

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationHttpClient.kt
@@ -169,7 +169,7 @@ class DestinationHttpClient {
         }
     }
 
-    private fun buildRequestBody(destination: WebhookDestination, message: MessageContent): String {
+    fun buildRequestBody(destination: WebhookDestination, message: MessageContent): String {
         val builder = XContentFactory.contentBuilder(XContentType.JSON)
         var keyName = "Content"
         // Slack webhook request body has required "text" as key name https://api.slack.com/messaging/webhooks

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/MessageContent.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/MessageContent.kt
@@ -49,6 +49,6 @@ class MessageContent(
     }
 
     fun buildWebhookMessage(): String {
-        return "$title $textDescription"
+        return "$title\n\n$textDescription"
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
@@ -115,7 +115,7 @@ internal object PluginSettings {
     private val DEFAULT_ALLOWED_CONFIG_TYPES = listOf(
         "slack",
         "chime",
-        "custom_webhook",
+        "webhook",
         "email",
         "smtp_account",
         "email_group"

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/Helpers.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/utils/Helpers.kt
@@ -29,7 +29,14 @@ package org.opensearch.notifications.spi.utils
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import org.opensearch.common.bytes.BytesReference
+import org.opensearch.common.xcontent.XContentBuilder
 
 fun <T : Any> logger(forClass: Class<T>): Lazy<Logger> {
     return lazy { LogManager.getLogger(forClass) }
 }
+
+/**
+ * Extension function for ES 6.3 and above that duplicates the ES 6.2 XContentBuilder.string() method.
+ */
+fun XContentBuilder.string(): String = BytesReference.bytes(this).utf8ToString()

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
@@ -182,4 +182,17 @@ internal class ChimeDestinationTests {
             throw ex
         }
     }
+
+    @Test
+    fun `test build webhook request body for chime should have title included and prevent escape`() {
+        val httpClient = DestinationHttpClient()
+        val title = "test Chime"
+        val messageText = "line1\nline2"
+        val url = "https://abc/com"
+        val expectedRequestBody = """{"Content":"$title\n\nline1\nline2"}"""
+        val destination = ChimeDestination(url)
+        val message = MessageContent(title, messageText)
+        val actualRequestBody = httpClient.buildRequestBody(destination, message)
+        assertEquals(expectedRequestBody, actualRequestBody)
+    }
 }

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
@@ -218,4 +218,17 @@ internal class CustomWebhookDestinationTests {
             throw ex
         }
     }
+
+    @Test
+    fun `test build request body for custom webhook should have title included and prevent escape`() {
+        val httpClient = DestinationHttpClient()
+        val title = "test custom webhook"
+        val messageText = "line1\nline2"
+        val url = "https://abc/com"
+        val expectedRequestBody = """{"Content":"$title\n\nline1\nline2"}"""
+        val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"), method)
+        val message = MessageContent(title, messageText)
+        val actualRequestBody = httpClient.buildRequestBody(destination, message)
+        assertEquals(expectedRequestBody, actualRequestBody)
+    }
 }

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/CustomWebhookDestinationTests.kt
@@ -39,8 +39,9 @@ import org.easymock.EasyMock
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.opensearch.notifications.spi.client.DestinationHttpClient
 import org.opensearch.notifications.spi.factory.DestinationFactoryProvider
 import org.opensearch.notifications.spi.factory.WebhookDestinationFactory
@@ -50,32 +51,31 @@ import org.opensearch.notifications.spi.model.destination.CustomWebhookDestinati
 import org.opensearch.notifications.spi.model.destination.DestinationType
 import org.opensearch.rest.RestStatus
 import java.net.MalformedURLException
+import java.util.stream.Stream
 
-@RunWith(Parameterized::class)
 internal class CustomWebhookDestinationTests {
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "Param: {0}={1}")
-        fun params(): Array<Array<Any>> {
-            return arrayOf(
-                arrayOf("POST", HttpPost::class.java),
-                arrayOf("PUT", HttpPut::class.java),
-                arrayOf("PATCH", HttpPatch::class.java)
+        fun methodToHttpRequestType(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("POST", HttpPost::class.java),
+                Arguments.of("PUT", HttpPut::class.java),
+                Arguments.of("PATCH", HttpPatch::class.java)
             )
-        }
+        @JvmStatic
+        fun escapeSequenceToRaw(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("\n", """\n"""),
+                Arguments.of("\t", """\t"""),
+                Arguments.of("\b", """\b"""),
+                Arguments.of("\r", """\r"""),
+                Arguments.of("\"", """\""""),
+            )
     }
 
-    @JvmField
-    @Parameterized.Parameter(0)
-    var method: String = ""
-
-    @JvmField
-    @Parameterized.Parameter(1)
-    var expectedHttpClass: Class<HttpUriRequest>? = null
-
-    @Test
-    @Throws(Exception::class)
-    fun `test custom webhook message null entity response`() {
+    @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")
+    @MethodSource("methodToHttpRequestType")
+    fun `test custom webhook message null entity response`(method: String, expectedHttpClass: Class<HttpUriRequest>) {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
 
         // The DestinationHttpClient replaces a null entity with "{}".
@@ -114,9 +114,10 @@ internal class CustomWebhookDestinationTests {
         assertEquals(expectedWebhookResponse.statusCode, actualCustomWebhookResponse.statusCode)
     }
 
-    @Test
+    @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")
+    @MethodSource("methodToHttpRequestType")
     @Throws(Exception::class)
-    fun `test custom webhook message empty entity response`() {
+    fun `test custom webhook message empty entity response`(method: String, expectedHttpClass: Class<HttpUriRequest>) {
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "")
 
@@ -153,9 +154,13 @@ internal class CustomWebhookDestinationTests {
         assertEquals(expectedWebhookResponse.statusCode, actualCustomWebhookResponse.statusCode)
     }
 
-    @Test
+    @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")
+    @MethodSource("methodToHttpRequestType")
     @Throws(Exception::class)
-    fun `test custom webhook message non-empty entity response`() {
+    fun `test custom webhook message non-empty entity response`(
+        method: String,
+        expectedHttpClass: Class<HttpUriRequest>
+    ) {
         val responseContent = "It worked!"
         val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
@@ -193,7 +198,7 @@ internal class CustomWebhookDestinationTests {
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `Test missing url will throw exception`() {
+    fun `Test missing url will throw exception`(method: String) {
         try {
             CustomWebhookDestination("", mapOf("headerKey" to "headerValue"), method)
         } catch (ex: Exception) {
@@ -203,7 +208,7 @@ internal class CustomWebhookDestinationTests {
     }
 
     @Test
-    fun testUrlInvalidMessage() {
+    fun testUrlInvalidMessage(method: String) {
         assertThrows<MalformedURLException> {
             CustomWebhookDestination("invalidUrl", mapOf("headerKey" to "headerValue"), method)
         }
@@ -219,14 +224,18 @@ internal class CustomWebhookDestinationTests {
         }
     }
 
-    @Test
-    fun `test build request body for custom webhook should have title included and prevent escape`() {
+    @ParameterizedTest
+    @MethodSource("escapeSequenceToRaw")
+    fun `test build request body for custom webhook should have title included and prevent escape`(
+        escapeSequence: String,
+        rawString: String
+    ) {
         val httpClient = DestinationHttpClient()
         val title = "test custom webhook"
-        val messageText = "line1\nline2"
+        val messageText = "line1${escapeSequence}line2"
         val url = "https://abc/com"
-        val expectedRequestBody = """{"Content":"$title\n\nline1\nline2"}"""
-        val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"), method)
+        val expectedRequestBody = """{"Content":"$title\n\nline1${rawString}line2"}"""
+        val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"), "POST")
         val message = MessageContent(title, messageText)
         val actualRequestBody = httpClient.buildRequestBody(destination, message)
         assertEquals(expectedRequestBody, actualRequestBody)

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/SlackDestinationTests.kt
@@ -173,4 +173,17 @@ internal class SlackDestinationTests {
             ChimeDestination("invalidUrl")
         }
     }
+
+    @Test
+    fun `test build webhook request body for slack should have title included and prevent escape`() {
+        val httpClient = DestinationHttpClient()
+        val title = "test Slack"
+        val messageText = "line1\nline2"
+        val url = "https://abc/com"
+        val expectedRequestBody = """{"text":"$title\n\nline1\nline2"}"""
+        val destination = SlackDestination(url)
+        val message = MessageContent(title, messageText)
+        val actualRequestBody = httpClient.buildRequestBody(destination, message)
+        assertEquals(expectedRequestBody, actualRequestBody)
+    }
 }

--- a/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
+++ b/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
@@ -116,7 +116,7 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
     }
 
     private fun getMessageTextDescription(feature: Feature, configId: String): String {
-        return "Test message content bodyfor config id $configId from feature ${feature.tag}" // TODO: change as spec
+        return "Test message content body for config id $configId\nfrom feature ${feature.tag}" // TODO: change as spec
     }
 
     private fun getMessageHtmlDescription(feature: Feature, configId: String): String {


### PR DESCRIPTION
### Description
- Use XContent builder to build json object for webhook request body and covert to string. This prevents escaping `\n` and keep it in the message string that gets passed
- Format the title and message body a bit
- fix the allowed config type literals in SPI plugin setting
- Add UT

### Issues Resolved
#238 
For Chime webhook we noticed that escape sequence like new line `\n` will lead to failed notification with `SearializationException` in the response from Chime webhook server.  Notice that Slack webhook feature doesn't have such issue before or after this change.
```
[2021-07-20T13:27:35,679][ERROR][o.o.n.s.f.WebhookDestinationFactory] [3c22fbe8fc7e.ant.amazon.com] Exception sending message: org.opensearch.notifications.spi.model.MessageContent@13f3b910
java.io.IOException: Failed: HttpResponseProxy{HTTP/1.1 400 Bad Request [Content-Type: application/json, Content-Length: 16, Connection: keep-alive, Date: Tue, 20 Jul 2021 20:27:35 GMT, x-amzn-ErrorType: SerializationException, x-amzn-RequestId: 2e761ad3-86a4-4efb-81f7-815baebba67c, X-Cache: Error from cloudfront, Via: 1.1 3f3347264bcaae7af741e2a2f692c6a1.cloudfront.net (CloudFront), X-Amz-Cf-Pop: SEA19-C3, X-Amz-Cf-Id: gYKFJ4ZLhRSmnJxxOg_ezECHcs_ZGKXG8su3-0gyejWEumMLCJx_tg==] ResponseEntityProxy{[Content-Type: application/json,Content-Length: 16,Chunked: false]}}
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
