### PR TITLE
Add mockk to Notification SPI to mock final/static class/method

### DIFF
--- a/notifications/spi/build.gradle
+++ b/notifications/spi/build.gradle
@@ -116,12 +116,29 @@ dependencies {
             "org.junit.jupiter:junit-jupiter-params:5.6.2",
             "org.easymock:easymock:4.0.1",
             "org.apache.logging.log4j:log4j-core:${versions.log4j}",
-            "org.opensearch.test:framework:${opensearch_version}",
+            'org.mockito:mockito-junit-jupiter:3.10.0',
+            'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',
+            'io.mockk:mockk:1.11.0',
+            'io.mockk:mockk-common:1.11.0',
+            'io.mockk:mockk-dsl:1.11.0',
+            'io.mockk:mockk-dsl-jvm:1.11.0',
+            'io.mockk:mockk-agent-api:1.11.0',
+            'io.mockk:mockk-agent-common:1.11.0',
+            'io.mockk:mockk-agent-jvm:1.11.0',
     )
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testCompile "org.mockito:mockito-core:3.10.0"
+    testCompile "org.opensearch.test:framework:${opensearch_version}"
+    testCompile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
+}
+
+configurations {
+    testCompile {
+        exclude group: 'org.elasticsearch', module: 'securemock' // resolve jarhell with mockito
+    }
 }
 
 shadowJar {

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/client/DestinationEmailClient.kt
@@ -30,7 +30,7 @@ import javax.mail.internet.MimeMessage
 /**
  * This class handles the connections to the given Destination.
  */
-open class DestinationEmailClient {
+class DestinationEmailClient {
 
     companion object {
         private val log by logger(DestinationEmailClient::class.java)
@@ -86,9 +86,8 @@ open class DestinationEmailClient {
     /*
      * This method is useful for mocking the client
      */
-    // TODO remove open keyword after adding other framework that can mock final class/method. e.g. Mockito2 ?
     @Throws(Exception::class)
-    open fun sendMessage(msg: Message?) {
+    fun sendMessage(msg: Message?) {
         Transport.send(msg)
     }
 

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/ChimeDestinationTests.kt
@@ -70,7 +70,7 @@ internal class ChimeDestinationTests {
 
         // The DestinationHttpClient replaces a null entity with "{}".
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
-
+        // TODO replace EasyMock in all UTs with mockk which fits Kotlin better
         val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
 

--- a/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/notifications/spi/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Description
- Remove `open` classifier of the email client class, because we can now use mockk to mock final/static class/method for testing

### Issues Resolved
- create a new TODO and opend an [issue](https://github.com/opensearch-project/notifications/issues/237) to deprecate the use of `Easymock` in SPI code

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
