### PR TITLE
Frontend: Fix importing path for api constant, update webhook placeholder

### DIFF
--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<SlackSettings /> spec renders the component 1`] = `
           class="euiFieldText euiFieldText--fullWidth"
           data-test-subj="create-channel-slack-webhook-input"
           id="random_html_id"
-          placeholder="https://hook.slack.com/services/XXXXX/XXXXX/XXXXX..."
+          placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."
           type="text"
           value="test webhook"
         />
@@ -71,7 +71,7 @@ exports[`<SlackSettings /> spec renders the component with error 1`] = `
           class="euiFieldText euiFieldText--fullWidth"
           data-test-subj="create-channel-slack-webhook-input"
           id="random_html_id"
-          placeholder="https://hook.slack.com/services/XXXXX/XXXXX/XXXXX..."
+          placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."
           type="text"
           value="test webhook"
         />

--- a/dashboards-notifications/public/pages/CreateChannel/components/SlackSettings.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/components/SlackSettings.tsx
@@ -47,7 +47,7 @@ export function SlackSettings(props: SlackSettingsProps) {
       <EuiFieldText
         fullWidth
         data-test-subj="create-channel-slack-webhook-input"
-        placeholder="https://hook.slack.com/services/XXXXX/XXXXX/XXXXX..."
+        placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."
         value={props.slackWebhook}
         onChange={(e) => props.setSlackWebhook(e.target.value)}
         isInvalid={context.inputErrors.slackWebhook.length > 0}

--- a/dashboards-notifications/server/routes/configRoutes.ts
+++ b/dashboards-notifications/server/routes/configRoutes.ts
@@ -14,7 +14,7 @@ import {
   ILegacyScopedClusterClient,
   IRouter,
 } from '../../../../src/core/server';
-import { NODE_API } from '../../../dashboards-notifications/common';
+import { NODE_API } from '../../common';
 import { joinRequestParams } from '../utils/helper';
 
 export function configRoutes(router: IRouter) {

--- a/dashboards-notifications/server/routes/eventRoutes.ts
+++ b/dashboards-notifications/server/routes/eventRoutes.ts
@@ -14,7 +14,7 @@ import {
   ILegacyScopedClusterClient,
   IRouter,
 } from '../../../../src/core/server';
-import { NODE_API } from '../../../dashboards-notifications/common';
+import { NODE_API } from '../../common';
 import { joinRequestParams } from '../utils/helper';
 
 export function eventRoutes(router: IRouter) {


### PR DESCRIPTION
### Description
The import path was redundant and becomes invalid when installed the plugin artifact. Also fixed slack webhook expected format in placeholder

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
