### PR TITLE
Support HOST_DENY_LIST and TOOLTIP_SUPPORT in plugin settings

### DIFF
--- a/notifications/spi/build.gradle
+++ b/notifications/spi/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 //        exclude module: 'annotations' // conflict with org.jetbrains:annotations, integTestRunner fails with error "codebase property already set"
 //    }
     compile "com.sun.mail:javax.mail:1.6.2"
-
+    implementation "com.github.seancfoley:ipaddress:5.3.3"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
@@ -11,10 +11,8 @@
 
 package org.opensearch.notifications.spi.model.destination
 
-import org.apache.http.client.utils.URIBuilder
+import org.opensearch.notifications.spi.setting.PluginSettings
 import org.opensearch.notifications.spi.utils.validateUrl
-import java.net.URI
-import java.net.URISyntaxException
 
 /**
  * This class holds the contents of generic webbook destination
@@ -25,16 +23,7 @@ abstract class WebhookDestination(
 ) : BaseDestination(destinationType) {
 
     init {
-        validateUrl(url)
-    }
-
-    @SuppressWarnings("SwallowedException")
-    internal fun buildUri(): URI {
-        return try {
-            URIBuilder(url).build()
-        } catch (exception: URISyntaxException) {
-            throw IllegalStateException("Error creating URI")
-        }
+        validateUrl(url, PluginSettings.hostDenyList)
     }
 
     override fun toString(): String {

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
@@ -75,6 +75,11 @@ internal object PluginSettings {
     private const val ALLOWED_CONFIG_TYPE_KEY = "$KEY_PREFIX.allowedConfigTypes"
 
     /**
+     * Setting to enable tooltip in UI
+     */
+    private const val TOOLTIP_SUPPORT_KEY = "$KEY_PREFIX.tooltip_support"
+
+    /**
      * Default email size limit as 10MB.
      */
     private const val DEFAULT_EMAIL_SIZE_LIMIT = 10000000
@@ -122,6 +127,11 @@ internal object PluginSettings {
     )
 
     /**
+     * Default disable tooltip support
+     */
+    private const val DEFAULT_TOOLTIP_SUPPORT = false
+
+    /**
      * list of allowed config types.
      */
     @Volatile
@@ -163,6 +173,12 @@ internal object PluginSettings {
     @Volatile
     var socketTimeout: Int
 
+    /**
+     * Tooltip support
+     */
+    @Volatile
+    var tooltipSupport: Boolean
+
     private const val DECIMAL_RADIX: Int = 10
 
     private val log by logger(javaClass)
@@ -190,6 +206,7 @@ internal object PluginSettings {
             ?: DEFAULT_CONNECTION_TIMEOUT_MILLISECONDS
         socketTimeout = (settings?.get(SOCKET_TIMEOUT_MILLISECONDS_KEY)?.toInt()) ?: DEFAULT_SOCKET_TIMEOUT_MILLISECONDS
         allowedConfigTypes = settings?.getAsList(ALLOWED_CONFIG_TYPE_KEY, null) ?: DEFAULT_ALLOWED_CONFIG_TYPES
+        tooltipSupport = settings?.getAsBoolean(TOOLTIP_SUPPORT_KEY, false) ?: DEFAULT_TOOLTIP_SUPPORT
 
         defaultSettings = mapOf(
             EMAIL_SIZE_LIMIT_KEY to emailSizeLimit.toString(DECIMAL_RADIX),
@@ -197,7 +214,8 @@ internal object PluginSettings {
             MAX_CONNECTIONS_KEY to maxConnections.toString(DECIMAL_RADIX),
             MAX_CONNECTIONS_PER_ROUTE_KEY to maxConnectionsPerRoute.toString(DECIMAL_RADIX),
             CONNECTION_TIMEOUT_MILLISECONDS_KEY to connectionTimeout.toString(DECIMAL_RADIX),
-            SOCKET_TIMEOUT_MILLISECONDS_KEY to socketTimeout.toString(DECIMAL_RADIX)
+            SOCKET_TIMEOUT_MILLISECONDS_KEY to socketTimeout.toString(DECIMAL_RADIX),
+            TOOLTIP_SUPPORT_KEY to tooltipSupport.toString()
         )
     }
 
@@ -245,6 +263,12 @@ internal object PluginSettings {
         NodeScope, Dynamic
     )
 
+    private val TOOLTIP_SUPPORT: Setting<Boolean> = Setting.boolSetting(
+        TOOLTIP_SUPPORT_KEY,
+        defaultSettings[TOOLTIP_SUPPORT_KEY]!!.toBoolean(),
+        NodeScope, Dynamic
+    )
+
     /**
      * Returns list of additional settings available specific to this plugin.
      *
@@ -258,7 +282,8 @@ internal object PluginSettings {
             MAX_CONNECTIONS_PER_ROUTE,
             CONNECTION_TIMEOUT_MILLISECONDS,
             SOCKET_TIMEOUT_MILLISECONDS,
-            ALLOWED_CONFIG_TYPES
+            ALLOWED_CONFIG_TYPES,
+            TOOLTIP_SUPPORT
         )
     }
     /**
@@ -273,6 +298,7 @@ internal object PluginSettings {
         maxConnectionsPerRoute = MAX_CONNECTIONS_PER_ROUTE.get(clusterService.settings)
         connectionTimeout = CONNECTION_TIMEOUT_MILLISECONDS.get(clusterService.settings)
         socketTimeout = SOCKET_TIMEOUT_MILLISECONDS.get(clusterService.settings)
+        tooltipSupport = TOOLTIP_SUPPORT.get(clusterService.settings)
     }
 
     /**
@@ -311,10 +337,15 @@ internal object PluginSettings {
             log.debug("$LOG_PREFIX:$SOCKET_TIMEOUT_MILLISECONDS_KEY -autoUpdatedTo-> $clusterSocketTimeout")
             socketTimeout = clusterSocketTimeout
         }
-        val clusterallowedConfigTypes = clusterService.clusterSettings.get(ALLOWED_CONFIG_TYPES)
-        if (clusterallowedConfigTypes != null) {
-            log.debug("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -autoUpdatedTo-> $clusterallowedConfigTypes")
-            allowedConfigTypes = clusterallowedConfigTypes
+        val clusterAllowedConfigTypes = clusterService.clusterSettings.get(ALLOWED_CONFIG_TYPES)
+        if (clusterAllowedConfigTypes != null) {
+            log.debug("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -autoUpdatedTo-> $clusterAllowedConfigTypes")
+            allowedConfigTypes = clusterAllowedConfigTypes
+        }
+        val clusterTooltipSupport = clusterService.clusterSettings.get(TOOLTIP_SUPPORT)
+        if (clusterTooltipSupport != null) {
+            log.debug("$LOG_PREFIX:$TOOLTIP_SUPPORT_KEY -autoUpdatedTo-> $clusterAllowedConfigTypes")
+            tooltipSupport = clusterTooltipSupport
         }
     }
 
@@ -355,6 +386,10 @@ internal object PluginSettings {
         clusterService.clusterSettings.addSettingsUpdateConsumer(SOCKET_TIMEOUT_MILLISECONDS) {
             socketTimeout = it
             log.info("$LOG_PREFIX:$SOCKET_TIMEOUT_MILLISECONDS_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(TOOLTIP_SUPPORT) {
+            tooltipSupport = it
+            log.info("$LOG_PREFIX:$TOOLTIP_SUPPORT_KEY -updatedTo-> $it")
         }
     }
 }

--- a/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
+++ b/notifications/spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
@@ -1,0 +1,51 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ *  Modifications Copyright OpenSearch Contributors. See
+ *  GitHub history for details.
+ */
+
+package org.opensearch.notifications.spi.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class ValidationHelpersTests {
+
+    private val hostDentyList = listOf(
+        "127.0.0.0/8",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "0.0.0.0/8",
+        "9.9.9.9" // ip
+    )
+
+    @Test
+    fun `test ips in denylist`() {
+        val ips = listOf(
+            "127.0.0.1", // 127.0.0.0/8
+            "10.0.0.1", // 10.0.0.0/8
+            "10.11.12.13", // 10.0.0.0/8
+            "172.16.0.1", // "172.16.0.0/12"
+            "192.168.0.1", // 192.168.0.0/16"
+            "0.0.0.1", // 0.0.0.0/8
+            "9.9.9.9"
+        )
+        for (ip in ips) {
+            assertEquals(true, isHostInDenylist("https://$ip", hostDentyList))
+        }
+    }
+
+    @Test
+    fun `test url in denylist`() {
+        val urls = listOf("https://www.amazon.com", "https://mytest.com", "https://mytest.com")
+        for (url in urls) {
+            assertEquals(false, isHostInDenylist(url, hostDentyList))
+        }
+    }
+}


### PR DESCRIPTION
### Description
- Add HTTP DENY LIST to plugin setting as alerting plugin has it
- Applyg host deny list to the url validator logic
- Add tooltip_support to plugin setting, which return a boolean. The is for UI to choose whether to display needed tooltips
- Add UT
- TODO: Add testing for plugin settings, will address in future PR

### Issues Resolved
#247 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
