### PR TITLE
downgrade to 1.0 and align common-utils in CI to use `notifiation-dev` branch

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -26,9 +26,9 @@ name: Test and Build Notifications
 on: [push, pull_request]
 
 env:
-  OPENSEARCH_VERSION: '1.1'
-  COMMON_UTILS_BRANCH: 'main'
-  OPENSEARCH_BRANCH: 'main'
+  OPENSEARCH_VERSION: '1.0'
+  COMMON_UTILS_BRANCH: 'notification-dev'
+  OPENSEARCH_BRANCH: '1.0'
 
 jobs:
   build:
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/common-utils'
-          ref: ${{ env.COMMON_UTILS_VERSION }}
+          ref: ${{ env.COMMON_UTILS_BRANCH }}
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -28,7 +28,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
         junit_version = System.getProperty("junit.version", "5.7.2")
     }

--- a/notifications/gradle.properties
+++ b/notifications/gradle.properties
@@ -25,4 +25,4 @@
 #
 #
 
-version = 1.1.0
+version = 1.0.0

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -179,6 +179,7 @@ object SendMessageActionHelper {
             ConfigType.EMAIL -> sendEmailMessage(configData as Email, childConfigs, message, eventStatus)
             ConfigType.SMTP_ACCOUNT -> null
             ConfigType.EMAIL_GROUP -> null
+            ConfigType.SNS -> null
         }
         return if (response == null) {
             log.warn("Cannot send message to destination for config id :${channel.docInfo.id}")


### PR DESCRIPTION
### Description
- For develop and test purpose. We can't upgrade to 1.0 now. The reliable artifact of upstream opensearch is still 1.0. Since though `common-utils` main branch has updated to 1.1, we decide to open a new branch `notification-dev` in `common-utils` which reverts the version bump commit, but including the all notification-related code change. 
- Update CI to align with `notification-dev` branch in common-utils
- Once other plugins(secuirty, any plugins using notification) and Dashboards completes the version bump. We can start doing the version bump

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
