### PR TITLE
Disallow inconsistent config types in update requests

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -238,6 +238,10 @@ object ConfigIndexingActions {
                 RestStatus.FORBIDDEN
             )
         }
+        if (currentConfigDoc.configDoc.config.configType != request.notificationConfig.configType) {
+            throw OpenSearchStatusException("Config type cannot be changed after creation", RestStatus.CONFLICT)
+        }
+
         val newMetadata = currentMetadata.copy(lastUpdateTime = Instant.now())
         val newConfigData = NotificationConfigDoc(newMetadata, request.notificationConfig)
         if (!operations.updateNotificationConfig(request.configId, newConfigData)) {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Throw exception if changing to a different config type for update requests

### Issues Resolved
#277 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
