### PR TITLE
Add back tests failed due to transient Mockito issue

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd notifications
-          ./gradlew build -PexcludeTests="**/SesChannelIT*, **/PluginActionTests*" -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}.0
+          ./gradlew build -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}.0
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Add back test failed earlier due to Mockito inline issue in Github workflow. Previous commit excluding the tests temporarily: https://github.com/opensearch-project/notifications/commit/2395c672f4cd3074fbd2d42a02bff2cbe1f904f9

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/251

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
