### PR TITLE
Add ses_account to feature api response

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
@@ -42,7 +42,7 @@ class GetPluginFeaturesIT : PluginRestTestCase() {
         val configTypes = getResponse.get("config_type_list").asJsonArray.map { it.asString }
         if (configTypes.contains(ConfigType.EMAIL.tag)) {
             Assert.assertTrue(configTypes.contains(ConfigType.EMAIL_GROUP.tag))
-            Assert.assertTrue(configTypes.contains(ConfigType.SMTP_ACCOUNT.tag))
+            Assert.assertTrue(configTypes.contains(ConfigType.SMTP_ACCOUNT.tag) || configTypes.contains(ConfigType.SES_ACCOUNT.tag))
         }
     }
 }

--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/setting/PluginSettings.kt
@@ -136,6 +136,7 @@ internal object PluginSettings {
         "webhook",
         "email",
         "sns",
+        "ses_account",
         "smtp_account",
         "email_group"
     )


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
add `ses_account` to `GET /_plugins/_notifications/features` API  response so frontend knows it's available

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
