### PR TITLE
Fix AWS region validation for SES destinations

### DIFF
--- a/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/SesDestination.kt
+++ b/notifications/spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/SesDestination.kt
@@ -28,7 +28,7 @@ class SesDestination(
 
     init {
         require(!Strings.isNullOrEmpty(awsRegion)) { "aws region should be provided" }
-        require(Regions.values().any { it.name == awsRegion }) { "aws region is not valid" }
+        require(Regions.values().any { it.getName() == awsRegion }) { "aws region is not valid" }
         validateEmail(fromAddress)
         validateEmail(recipient)
     }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
When validating if aws region exists, use `getName()` instead of `.name` because `it.name` returns `US_WEST_2` instead of `us-west-2`.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
