### PR TITLE
Add additional CRUD tests for Chime

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -265,6 +265,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.CONFLICT.status
         )
     }
+
     fun `test BAD create request with invalid webhook URL`() {
         // Create sample config request reference
         val sampleChimeConfigData = Chime("https://")
@@ -299,6 +300,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.INTERNAL_SERVER_ERROR.status
         )
     }
+
     fun `test BAD delete request on non-existent config ID`() {
         val configId = "abcdefghijk"
         executeRequest(
@@ -308,6 +310,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.NOT_FOUND.status
         )
     }
+
     fun `test update Chime webhook URL`() {
         // Create sample config request reference
         val sampleChime = Chime("https://domain.com/sample_chime_url#1234567890")


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

Add additional tests to Chime CRUD tests to test more use cases/edge cases.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
