### PR TITLE
Fix route for notifications stats

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationStatsRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationStatsRestHandler.kt
@@ -42,7 +42,14 @@ internal class NotificationStatsRestHandler : BaseRestHandler() {
      * {@inheritDoc}
      */
     override fun routes(): List<Route> {
-        return listOf()
+        return listOf(
+            /**
+             * Get Notifications Stats
+             * Request body: None
+             * TODO: Add response body in common-utils
+             */
+            Route(GET, NOTIFICATION_STATS_URL)
+        )
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

Fix the route for notifications backend stats so the API can be called correctly
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
