### PR TITLE
Hide inverting filters functionality from UI

### DIFF
--- a/dashboards-notifications/public/pages/Notifications/__tests__/Filters.test.tsx
+++ b/dashboards-notifications/public/pages/Notifications/__tests__/Filters.test.tsx
@@ -52,8 +52,8 @@ describe('<Filters /> spec', () => {
 
     utils.getByText('Channel: test').click();
     utils.getByText('Re-enable').click();
-    utils.getByText('Channel: test').click();
-    utils.getByText('Exclude results').click();
+    // utils.getByText('Channel: test').click();
+    // utils.getByText('Exclude results').click();
     utils.getByText('Channel: test').click();
     utils.getByText('Delete').click();
   });

--- a/dashboards-notifications/public/pages/Notifications/__tests__/GlobalFilterButton.test.tsx
+++ b/dashboards-notifications/public/pages/Notifications/__tests__/GlobalFilterButton.test.tsx
@@ -68,13 +68,13 @@ describe('<GlobalFilterButton /> spec', () => {
     utils.getByText('Enable all').click();
     utils.getByLabelText('Change all filters').click();
     utils.getByText('Disable all').click();
-    utils.getByLabelText('Change all filters').click();
-    utils.getByText('Invert inclusion').click();
+    // utils.getByLabelText('Change all filters').click();
+    // utils.getByText('Invert inclusion').click();
     utils.getByLabelText('Change all filters').click();
     utils.getByText('Invert enabled/disabled').click();
     utils.getByLabelText('Change all filters').click();
     utils.getByText('Remove all').click();
 
-    expect(setFilters).toBeCalledTimes(5);
+    expect(setFilters).toBeCalledTimes(4);
   });
 });

--- a/dashboards-notifications/public/pages/Notifications/__tests__/filterHelpers.test.tsx
+++ b/dashboards-notifications/public/pages/Notifications/__tests__/filterHelpers.test.tsx
@@ -49,14 +49,17 @@ describe('test filter helper functions', () => {
 
   it('returns filter operator options', () => {
     const channelOperators = getFilterOperatorOptions('Channel');
-    expect(channelOperators).toEqual([{ label: 'is' }, { label: 'is not' }]);
+    expect(channelOperators).toEqual([
+      { label: 'is' },
+      // { label: 'is not' },
+    ]);
 
     const sourceOperators = getFilterOperatorOptions('Source');
     expect(sourceOperators).toEqual([
       { label: 'is' },
-      { label: 'is not' },
+      // { label: 'is not' },
       { label: 'is one of' },
-      { label: 'is not one of' },
+      // { label: 'is not one of' },
     ]);
   });
 

--- a/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/Filters.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/Filters.tsx
@@ -82,19 +82,19 @@ export function Filters(props: FiltersProps) {
           icon: <EuiIcon type="invert" size="m" />,
           panel: 1,
         },
-        {
-          name: `${filter.inverted ? 'Include' : 'Exclude'} results`,
-          icon: (
-            <EuiIcon
-              type={filter.inverted ? 'plusInCircle' : 'minusInCircle'}
-              size="m"
-            />
-          ),
-          onClick: () => {
-            filter.inverted = !filter.inverted;
-            setFilter(filter, index);
-          },
-        },
+        // {
+        //   name: `${filter.inverted ? 'Include' : 'Exclude'} results`,
+        //   icon: (
+        //     <EuiIcon
+        //       type={filter.inverted ? 'plusInCircle' : 'minusInCircle'}
+        //       size="m"
+        //     />
+        //   ),
+        //   onClick: () => {
+        //     filter.inverted = !filter.inverted;
+        //     setFilter(filter, index);
+        //   },
+        // },
         {
           name: filter.disabled ? 'Re-enable' : 'Temporarily disable',
           icon: (

--- a/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/GlobalFilterButton.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/SearchBar/Filter/GlobalFilterButton.tsx
@@ -65,19 +65,19 @@ export function GlobalFilterButton(props: GlobalFilterButtonProps) {
             setIsPopoverOpen(false);
           },
         },
-        {
-          name: 'Invert inclusion',
-          icon: <EuiIcon type="invert" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                inverted: !filter.inverted,
-              }))
-            );
-            setIsPopoverOpen(false);
-          },
-        },
+        // {
+        //   name: 'Invert inclusion',
+        //   icon: <EuiIcon type="invert" size="m" />,
+        //   onClick: () => {
+        //     props.setFilters(
+        //       props.filters.map((filter) => ({
+        //         ...filter,
+        //         inverted: !filter.inverted,
+        //       }))
+        //     );
+        //     setIsPopoverOpen(false);
+        //   },
+        // },
         {
           name: 'Invert enabled/disabled',
           icon: <EuiIcon type="eye" size="m" />,

--- a/dashboards-notifications/public/pages/Notifications/components/SearchBar/utils/filterHelpers.tsx
+++ b/dashboards-notifications/public/pages/Notifications/components/SearchBar/utils/filterHelpers.tsx
@@ -68,13 +68,16 @@ export const getFilterFieldOptions = () => {
 
 export const getFilterOperatorOptions = (field: FilterFieldType) => {
   if (field === 'Channel' || field === 'Status') {
-    return [{ label: 'is' }, { label: 'is not' }];
+    return [
+      { label: 'is' },
+      // { label: 'is not' },
+    ];
   }
   return [
     { label: 'is' },
-    { label: 'is not' },
+    // { label: 'is not' },
     { label: 'is one of' },
-    { label: 'is not one of' },
+    // { label: 'is not one of' },
   ];
 };
 


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
The backend does not support negated queries like `must_not` yet (issue #204), disable invert filter functionality in UI
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
