### PR TITLE
Downgrade jackson to 2.11.4 to be consistent with core

### DIFF
--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -74,12 +74,12 @@ configurations.all {
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
         force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-core:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-annotations:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-databind:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-core:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-annotations:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-databind:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4" // resolve for amazonaws
         force "junit:junit:4.12" // resolve for amazonaws
     }
 }

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -87,12 +87,12 @@ configurations.all {
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
         force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-core:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-annotations:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-databind:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.3" // resolve for amazonaws
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-core:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-annotations:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-databind:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4" // resolve for amazonaws
         force "junit:junit:4.12" // resolve for amazonaws
     }
 }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
After refactoring project structure, opensearch throws an exception due to inconsistent jackson versions (`java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/util/JacksonFeature`). Core is using 2.11.4 so downgrading to fix this issue.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
