### PR TITLE
Add notifciation-core plugin settings and support adding smtp email credentials

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/WebhookDestination.kt
@@ -22,8 +22,7 @@ abstract class WebhookDestination(
 ) : BaseDestination(destinationType) {
 
     init {
-        // TODO tmp change for dev purpose, need to load from plugin settings
-        validateUrl(url, listOf("fake"))
+        validateUrl(url)
     }
 
     override fun toString(): String {

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
@@ -34,12 +34,9 @@ import org.apache.http.client.methods.HttpPut
 import org.opensearch.common.Strings
 import java.net.URL
 
-fun validateUrl(urlString: String, hostDenyList: List<String>) {
+fun validateUrl(urlString: String) {
     require(!Strings.isNullOrEmpty(urlString)) { "url is null or empty" }
     require(isValidUrl(urlString)) { "Invalid URL or unsupported" }
-    require(!isHostInDenylist(urlString, hostDenyList)) {
-        "Host of url is denied, based on plugin setting [notification.core.email.host_deny_list]"
-    }
 }
 
 fun validateEmail(email: String) {

--- a/notifications/core/src/main/config/notifications-core.yml
+++ b/notifications/core/src/main/config/notifications-core.yml
@@ -1,0 +1,41 @@
+---
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+
+##
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+##
+
+# configuration file for the notifications-core plugin
+opensearch.notifications.core:
+  email:
+    sizeLimit: 10000
+    minimumHeaderLength: 100
+    host_deny_list: []
+  http:
+    maxConnections: 60
+    maxConnectionPerRoute: 20
+    connectionTimeout: 5000 # in milliseconds
+    socketTimeout: 50000
+  allowedConfigTypes: ["slack","chime","webhook","email","sns","ses_account","smtp_account","email_group"]
+  tooltip_support: true

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
@@ -44,8 +44,8 @@ class NotificationCorePlugin : ReloadablePlugin, Plugin(), ExtensiblePlugin {
     internal companion object {
         private val log by logger(NotificationCorePlugin::class.java)
 
-        const val PLUGIN_NAME = "opensearch-notifications"
-        const val LOG_PREFIX = "notifications"
+        const val PLUGIN_NAME = "opensearch-notifications-core"
+        const val LOG_PREFIX = "notifications-core"
     }
     /**
      * {@inheritDoc}

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -48,6 +48,7 @@ import org.opensearch.notifications.core.setting.PluginSettings
 import org.opensearch.notifications.core.utils.OpenForTesting
 import org.opensearch.notifications.core.utils.logger
 import org.opensearch.notifications.core.utils.string
+import org.opensearch.notifications.core.utils.validateUrlHost
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
 import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
@@ -113,6 +114,8 @@ class DestinationHttpClient {
     fun execute(destination: WebhookDestination, message: MessageContent, referenceId: String): String {
         var response: CloseableHttpResponse? = null
         return try {
+            // validate webhook url against host_deny_list in plugin settings
+            validateUrlHost(destination.url, PluginSettings.hostDenyList)
             response = getHttpResponse(destination, message)
             validateResponseStatus(response)
             val responseString = getResponseString(response)

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
@@ -225,7 +225,7 @@ internal object PluginSettings {
         var settings: Settings? = null
         val configDirName = BootstrapInfo.getSystemProperties()?.get("opensearch.path.conf")?.toString()
         if (configDirName != null) {
-            val defaultSettingYmlFile = Path.of(configDirName, PLUGIN_NAME, "notifications.yml")
+            val defaultSettingYmlFile = Path.of(configDirName, PLUGIN_NAME, "notifications-core.yml")
             try {
                 settings = Settings.builder().loadFromPath(defaultSettingYmlFile).build()
             } catch (e: IOException) {
@@ -361,6 +361,7 @@ internal object PluginSettings {
         socketTimeout = SOCKET_TIMEOUT_MILLISECONDS.get(clusterService.settings)
         tooltipSupport = TOOLTIP_SUPPORT.get(clusterService.settings)
         hostDenyList = HOST_DENY_LIST.get(clusterService.settings)
+        destinationSettings = loadDestinationSettings(clusterService.settings)
     }
 
     /**
@@ -469,7 +470,7 @@ internal object PluginSettings {
         // If this logic needs to be expanded to support other Destinations, different groups can be retrieved similar
         // to emailAccountNames based on the setting namespace and SecureDestinationSettings should be expanded to support
         // these new settings.
-        val emailAccountNames: Set<String> = settings.getGroups(EMAIL_DESTINATION_SETTING_PREFIX).keys
+        val emailAccountNames: Set<String> = settings.getGroups(EMAIL_DESTINATION_SETTING_PREFIX, true).keys
         val emailAccounts: MutableMap<String, SecureDestinationSettings> = mutableMapOf()
         for (emailAccountName in emailAccountNames) {
             // Only adding the settings if they exist

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/transport/WebhookDestinationTransport.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/transport/WebhookDestinationTransport.kt
@@ -47,10 +47,18 @@ internal class WebhookDestinationTransport : DestinationTransport<WebhookDestina
             val response = destinationHttpClient.execute(destination, message, referenceId)
             DestinationMessageResponse(RestStatus.OK.status, response)
         } catch (exception: IOException) {
-            log.error("Exception sending message $referenceId: $message", exception)
+            log.error("Exception sending webhook message $referenceId: $message", exception)
             DestinationMessageResponse(
                 RestStatus.INTERNAL_SERVER_ERROR.status,
-                "Failed to send message ${exception.message}"
+                "Failed to send webhook message ${exception.message}"
+            )
+        } catch (illegalArgumentException: IllegalArgumentException) {
+            log.error(
+                "Exception sending webhook message: message creation failed with status:${illegalArgumentException.message}"
+            )
+            DestinationMessageResponse(
+                RestStatus.BAD_REQUEST.status,
+                "Webhook message creation failed with status:${illegalArgumentException.message}"
             )
         }
     }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -34,10 +34,13 @@ import org.apache.http.client.methods.HttpPut
 import org.opensearch.common.Strings
 import java.net.URL
 
-fun validateUrl(urlString: String, hostDenyList: List<String>) {
+fun validateUrl(urlString: String) {
     require(!Strings.isNullOrEmpty(urlString)) { "url is null or empty" }
     require(isValidUrl(urlString)) { "Invalid URL or unsupported" }
-    require(!isHostInDenylist(urlString, hostDenyList)) {
+}
+
+fun validateUrlHost(urlString: String, hostDenyList: List<String>) {
+    require(!org.opensearch.notifications.spi.utils.isHostInDenylist(urlString, hostDenyList)) {
         "Host of url is denied, based on plugin setting [notification.core.email.host_deny_list]"
     }
 }


### PR DESCRIPTION
### Description
This PR is refactored from the previous #289 , since we recently have a project structure refactor. 

Notice: APIs to retrieve plugin features and config types remain the same 

e.g. 

```
localhost:9200/_plugins/_notifications/features

{
    "config_type_list": [
        "slack",
        "chime",
        "webhook",
        "email",
        "sns",
        "ses_account",
        "smtp_account",
        "email_group"
    ],
    "plugin_features": {
        "opensearch.notifications.core.email.sizeLimit": "10000",
        "opensearch.notifications.core.email.minimumHeaderLength": "100",
        "opensearch.notifications.core.http.maxConnections": "60",
        "opensearch.notifications.core.http.maxConnectionPerRoute": "20",
        "opensearch.notifications.core.http.connectionTimeout": "5000",
        "opensearch.notifications.core.http.socketTimeout": "50000",
        "opensearch.notifications.core.tooltip_support": "true"
    }
}

```

#### Major change
 - revisit the plugin setting of notification-core after refactor #315, and add missing part to make it fully functional
 - Make `Notificaiton-core plugin` implements `ReloadablePlugin` and implement `reload` mehthod, so that credentials added by `opensearch-keystore` can be applied without rebooting cluster, simply by `POST _nodes/reload_secure_settings`
 - add `notifications-core.yml` with default values, similar to `notifications.yml` 

#### Other change

- refactor the `validateUrl` logic to seperate the basic url format check and the host checker(depends on host_deny_list in notification-core plugin settings). Becuase the webhook model is defined in SPI but from SPI we don't have the access to the plugin settings. So in spi we only check format, and in core-plugin, we add additional check against `host_deny_list` 
 

#### Additional notes

- [How to add credentials using `opensearch-keystore`?](https://opensearch.org/docs/monitoring-plugins/alerting/monitors/#email-as-a-destination)
- Remeber to turn off the security settings of email service providers, such as 
  - 2-step verification
  - ...


### Issues Resolved
#278 
#279 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
