### PR TITLE
Add support for other plugins to use notifications without requiring a code change

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationCore.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationCore.kt
@@ -20,6 +20,11 @@ interface NotificationCore {
     fun getAllowedConfigTypes(): List<String>
 
     /**
+     * Get list of allowed config features
+     */
+    fun getAllowedConfigFeatures(): List<String>
+
+    /**
      * Get map of plugin features
      */
     fun getPluginFeatures(): Map<String, String>

--- a/notifications/core/src/main/config/notifications-core.yml
+++ b/notifications/core/src/main/config/notifications-core.yml
@@ -31,11 +31,12 @@ opensearch.notifications.core:
   email:
     sizeLimit: 10000
     minimumHeaderLength: 100
-    host_deny_list: []
   http:
     maxConnections: 60
     maxConnectionPerRoute: 20
     connectionTimeout: 5000 # in milliseconds
     socketTimeout: 50000
+    hostDenyList: []
   allowedConfigTypes: ["slack","chime","webhook","email","sns","ses_account","smtp_account","email_group"]
-  tooltip_support: true
+  allowedConfigFeatures: ["alerting", "index_management", "reports"]
+  tooltipSupport: true

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCoreImpl.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCoreImpl.kt
@@ -74,12 +74,25 @@ object NotificationCoreImpl : NotificationCore {
     }
 
     /**
+     * Get list of allowed config features
+     */
+    override fun getAllowedConfigFeatures(): List<String> {
+        return AccessController.doPrivileged(
+            PrivilegedAction {
+                PluginSettings.allowedConfigFeatures
+            } as PrivilegedAction<List<String>>?
+        )
+    }
+
+    /**
      * Get map of plugin features
      */
     override fun getPluginFeatures(): Map<String, String> {
         return AccessController.doPrivileged(
             PrivilegedAction {
-                PluginSettings.defaultSettings
+                mapOf(
+                    Pair("tooltip_support", "${PluginSettings.tooltipSupport}")
+                )
             } as PrivilegedAction<Map<String, String>>?
         )
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
@@ -80,9 +80,11 @@ internal class GetPluginFeaturesAction @Inject constructor(
         user: User?
     ): GetPluginFeaturesResponse {
         val allowedConfigTypes = CoreProvider.core.getAllowedConfigTypes()
+        val allowedConfigFeatures = CoreProvider.core.getAllowedConfigFeatures()
         val pluginFeatures = CoreProvider.core.getPluginFeatures()
         return GetPluginFeaturesResponse(
             allowedConfigTypes,
+            allowedConfigFeatures,
             pluginFeatures
         )
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -54,6 +54,7 @@ import org.opensearch.commons.notifications.model.SmtpAccount
 import org.opensearch.commons.notifications.model.Sns
 import org.opensearch.commons.notifications.model.Webhook
 import org.opensearch.commons.utils.logger
+import org.opensearch.notifications.CoreProvider
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
 import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.notifications.model.DocMetadata
@@ -189,6 +190,14 @@ object ConfigIndexingActions {
     }
 
     private fun validateConfig(config: NotificationConfig, user: User?) {
+        config.features.forEach {
+            if (!CoreProvider.core.getAllowedConfigFeatures().contains(it)) {
+                throw OpenSearchStatusException(
+                    "NotificationConfig with type feature $it is not acceptable",
+                    RestStatus.NOT_ACCEPTABLE
+                )
+            }
+        }
         when (config.configType) {
             ConfigType.NONE -> throw OpenSearchStatusException(
                 "NotificationConfig with type NONE is not acceptable",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
@@ -199,6 +199,9 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
     NOTIFICATIONS_SEND_MESSAGE_USER_ERROR_NOT_FOUND(
         "notifications.send_message.user_error.not_found", RollingCounter()
     ),
+    NOTIFICATIONS_SEND_MESSAGE_USER_ERROR_FEATURE_NOT_FOUND(
+        "notifications.send_message.user_error.feature_not_found", RollingCounter()
+    ),
     NOTIFICATIONS_SEND_MESSAGE_SYSTEM_ERROR(
         "notifications.send_message.system_error",
         RollingCounter()

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -91,6 +91,13 @@ object SendMessageActionHelper {
         val channelMessage = request.channelMessage
         val channelIds = request.channelIds.toSet()
         val user: User? = User.parse(request.threadContext)
+        if (!CoreProvider.core.getAllowedConfigFeatures().contains(request.eventSource.feature)) {
+            Metrics.NOTIFICATIONS_SEND_MESSAGE_USER_ERROR_FEATURE_NOT_FOUND.counter.increment()
+            throw OpenSearchStatusException(
+                "Source ${request.eventSource.feature} Feature not enabled",
+                RestStatus.BAD_REQUEST
+            )
+        }
         val createdTime = Instant.now()
         userAccess.validateUser(user)
         val channels = getConfigs(channelIds)

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
@@ -27,7 +27,8 @@ class GetPluginFeaturesIT : PluginRestTestCase() {
             "",
             RestStatus.OK.status
         )
-        Assert.assertFalse(getResponse.get("config_type_list").asJsonArray.isEmpty)
+        Assert.assertFalse(getResponse.get("allowed_config_type_list").asJsonArray.isEmpty)
+        Assert.assertFalse(getResponse.get("allowed_config_feature_list").asJsonArray.isEmpty)
         val pluginFeatures = getResponse.get("plugin_features").asJsonObject
         Assert.assertFalse(pluginFeatures.keySet().isEmpty())
     }
@@ -39,7 +40,7 @@ class GetPluginFeaturesIT : PluginRestTestCase() {
             "",
             RestStatus.OK.status
         )
-        val configTypes = getResponse.get("config_type_list").asJsonArray.map { it.asString }
+        val configTypes = getResponse.get("allowed_config_type_list").asJsonArray.map { it.asString }
         if (configTypes.contains(ConfigType.EMAIL.tag)) {
             Assert.assertTrue(configTypes.contains(ConfigType.EMAIL_GROUP.tag))
             Assert.assertTrue(configTypes.contains(ConfigType.SMTP_ACCOUNT.tag) || configTypes.contains(ConfigType.SES_ACCOUNT.tag))

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -157,9 +157,10 @@ internal class PluginActionTests {
     @Test
     fun `Get plugin features action should call back action listener`() {
         val allowedConfigTypes = listOf("type1")
+        val allowedConfigFeatures = listOf("feature1")
         val pluginFeatures = mapOf(Pair("FeatureKey1", "Feature1"))
         val request = mock(GetPluginFeaturesRequest::class.java)
-        val response = GetPluginFeaturesResponse(allowedConfigTypes, pluginFeatures)
+        val response = GetPluginFeaturesResponse(allowedConfigTypes, allowedConfigFeatures, pluginFeatures)
 
         val getPluginFeaturesAction = GetPluginFeaturesAction(
             transportService, client, actionFilters, xContentRegistry


### PR DESCRIPTION
### Description
Add support for other plugins to use notifications without requiring a code change

Also added validation when saving configuration and sending notification

Signed-off-by: @akbhatta

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
