### PR TITLE
Frontend: fix validation for combo box and send test message button

### DIFF
--- a/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
+++ b/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
@@ -92,7 +92,9 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
     {
       label: 'Send test message',
       disabled:
-        props.channel.feature_list.length === 0 || !props.channel.config_id,
+        props.channel.feature_list.length === 0 ||
+        !props.channel.config_id ||
+        !props.channel.is_enabled,
       action: sendTestMessage,
     },
     {

--- a/dashboards-notifications/public/pages/CreateChannel/components/EmailSettings.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/components/EmailSettings.tsx
@@ -320,7 +320,12 @@ export function EmailSettings(props: EmailSettingsProps) {
                   recipientGroupOptions,
                   setRecipientGroupOptions,
                   props.selectedRecipientGroupOptions,
-                  props.setSelectedRecipientGroupOptions
+                  props.setSelectedRecipientGroupOptions,
+                  (options) =>
+                    context.setInputErrors({
+                      ...context.inputErrors,
+                      recipients: validateRecipients(options),
+                    })
                 )
               }
               customOptionText={'Add {searchValue} as a default recipient'}

--- a/dashboards-notifications/public/pages/Emails/__tests__/helper.test.ts
+++ b/dashboards-notifications/public/pages/Emails/__tests__/helper.test.ts
@@ -77,13 +77,15 @@ describe('handles combo box create option', () => {
     const selectedOptions = [options[0]];
     const setOptions = jest.fn();
     const setSelectedOptions = jest.fn();
+    const setInputError = jest.fn();
     onComboBoxCreateOption(
       'new-option',
       options,
       options,
       setOptions,
       selectedOptions,
-      setSelectedOptions
+      setSelectedOptions,
+      setInputError
     );
     expect(setOptions).toBeCalledWith([...options, { label: 'new-option' }]);
     expect(setSelectedOptions).toBeCalledWith([...selectedOptions, { label: 'new-option' }]);
@@ -94,13 +96,15 @@ describe('handles combo box create option', () => {
     const selectedOptions = [options[0]];
     const setOptions = jest.fn();
     const setSelectedOptions = jest.fn();
+    const setInputError = jest.fn();
     onComboBoxCreateOption(
       'existing-option',
       options,
       options,
       setOptions,
       selectedOptions,
-      setSelectedOptions
+      setSelectedOptions,
+      setInputError
     );
     expect(setOptions).not.toBeCalled();
     expect(setSelectedOptions).toBeCalledWith([...selectedOptions, { label: 'existing-option' }]);

--- a/dashboards-notifications/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/dashboards-notifications/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -130,7 +130,12 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
                 props.emailOptions,
                 props.setEmailOptions,
                 props.selectedEmailOptions,
-                props.setSelectedEmailOptions
+                props.setSelectedEmailOptions,
+                (options) =>
+                  props.setInputErrors({
+                    ...props.inputErrors,
+                    emailOptions: validateRecipientGroupEmails(options),
+                  })
               )
             }
             customOptionText={'Add {searchValue} as an email address'}

--- a/dashboards-notifications/public/pages/Emails/utils/helper.ts
+++ b/dashboards-notifications/public/pages/Emails/utils/helper.ts
@@ -75,7 +75,8 @@ export const onComboBoxCreateOption = (
   options: Array<EuiComboBoxOptionOption<string>>,
   setOptions: (options: Array<EuiComboBoxOptionOption<string>>) => void,
   selectedOptions: Array<EuiComboBoxOptionOption<string>>,
-  setSelectedOptions: (options: Array<EuiComboBoxOptionOption<string>>) => void
+  setSelectedOptions: (options: Array<EuiComboBoxOptionOption<string>>) => void,
+  setInputError: (newOptions: Array<EuiComboBoxOptionOption<string>>) => void
 ) => {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
   if (!normalizedSearchValue) return;
@@ -88,5 +89,7 @@ export const onComboBoxCreateOption = (
   ) {
     setOptions([...options, newOption]);
   }
-  setSelectedOptions([...selectedOptions, newOption]);
+  const newOptions = [...selectedOptions, newOption];
+  setSelectedOptions(newOptions);
+  setInputError(newOptions);
 };


### PR DESCRIPTION
### Description
- Disable send test message if channel is muted 
- Validate input when creating combo box options, otherwise component onblur happens before state update and UI says the combo box is empty
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
