### PR TITLE
Frontend: use text_query for search bar to include only text fields

### DIFF
--- a/dashboards-notifications/server/routes/configRoutes.ts
+++ b/dashboards-notifications/server/routes/configRoutes.ts
@@ -62,7 +62,7 @@ export function configRoutes(router: IRouter) {
             sort_order: request.query.sort_order,
             config_type,
             ...(feature_list && { feature_list }),
-            ...(query && { query }),
+            ...(query && { text_query: query }), // text_query will exclude keyword fields
             ...(config_id_list && { config_id_list }),
           }
         );

--- a/dashboards-notifications/server/routes/eventRoutes.ts
+++ b/dashboards-notifications/server/routes/eventRoutes.ts
@@ -74,7 +74,7 @@ export function eventRoutes(router: IRouter) {
           max_items: request.query.max_items,
           sort_field: request.query.sort_field,
           sort_order: request.query.sort_order,
-          ...(query && { query }),
+          ...(query && { text_query: query }),
           ...(last_updated_time_ms && { last_updated_time_ms }),
           ...(config_name && { 'status_list.config_name': config_name }),
           ...(config_type && { 'status_list.config_type': config_type }),


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Use text_query for search bar to include only text fields (so keyword fields like config type and source are not included)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
