### PR TITLE
Fix multistatus

### DIFF
--- a/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
+++ b/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
@@ -60,22 +60,29 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
 
   const sendTestMessage = async () => {
     try {
-      const eventId = await servicesContext.eventService
-        .sendTestMessage(props.channel.config_id, props.channel.feature_list[0])
-        .then((response) => response.event_id);
-
-      await servicesContext.eventService
-        .getNotification(eventId)
-        .then((response) => {
-          if (!response.success) {
-            const error = new Error('Failed to send the test message.');
-            error.stack = JSON.stringify(response.status_list, null, 2);
-            throw error;
-          }
-        });
-      coreContext.notifications.toasts.addSuccess(
-        'Successfully sent a test message.'
+      const response = await servicesContext.eventService.sendTestMessage(
+        props.channel.config_id,
+        props.channel.feature_list[0]
       );
+      if (response.event_id != null) {
+        await servicesContext.eventService
+          .getNotification(response.event_id)
+          .then((response) => {
+            if (!response.success) {
+              const error = new Error('Failed to send the test message.');
+              error.stack = JSON.stringify(response.status_list, null, 2);
+              throw error;
+            }
+          });
+        coreContext.notifications.toasts.addSuccess(
+          'Successfully sent a test message.'
+        );
+      } else {
+        console.error(response);
+        const error = new Error('Failed to send the test message.');
+        error.stack = JSON.stringify(response, null, 2);
+        throw error;
+      }
     } catch (error) {
       coreContext.notifications.toasts.addError(error?.body || error, {
         title: 'Failed to send the test message.',

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -419,7 +419,7 @@ object SendMessageActionHelper {
             val status = it.deliveryStatus
             log.info("$LOG_PREFIX:${email.emailAccountID}:statusCode=${status.statusCode}, statusText=${status.statusText}")
             if (overallStatus != status.statusCode) {
-                overallStatus = RestStatus.MULTI_STATUS.name
+                overallStatus = RestStatus.MULTI_STATUS.status.toString()
                 overallStatusText = "Errors"
             }
         }


### PR DESCRIPTION
### Description
- Backend: use `RestStatus.MULTI_STATUS.status.toString()` instead of enum name so it can be parsed to int
- Frontend: show error if backend throws error and the response cannot be parsed
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
