### PR TITLE
Frontend: add dropdown for custom webhook method and type

### DIFF
--- a/dashboards-notifications/models/interfaces.ts
+++ b/dashboards-notifications/models/interfaces.ts
@@ -25,6 +25,7 @@
  */
 
 import { Direction } from '@elastic/eui';
+import { MethodType } from '../public/pages/Channels/types';
 import {
   CHANNEL_TYPE,
   ENCRYPTION_TYPE,
@@ -79,6 +80,7 @@ export interface ChannelItemType extends ConfigType {
   webhook?: {
     url: string;
     header_params: object;
+    method: MethodType;
   };
   email?: {
     email_account_id: string;

--- a/dashboards-notifications/models/interfaces.ts
+++ b/dashboards-notifications/models/interfaces.ts
@@ -25,7 +25,7 @@
  */
 
 import { Direction } from '@elastic/eui';
-import { MethodType } from '../public/pages/Channels/types';
+import { WebhookMethodType } from '../public/pages/Channels/types';
 import {
   CHANNEL_TYPE,
   ENCRYPTION_TYPE,
@@ -80,7 +80,7 @@ export interface ChannelItemType extends ConfigType {
   webhook?: {
     url: string;
     header_params: object;
-    method: MethodType;
+    method: WebhookMethodType;
   };
   email?: {
     email_account_id: string;

--- a/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
@@ -233,12 +233,12 @@ exports[`<ChannelSettingsDetails /> spec renders Webhook channel 1`] = `
         <dt
           class="euiDescriptionList__title"
         >
-          Host
+          Method
         </dt>
         <dd
           class="euiDescriptionList__description"
         >
-          host
+          POST
         </dd>
       </dl>
     </div>
@@ -252,12 +252,12 @@ exports[`<ChannelSettingsDetails /> spec renders Webhook channel 1`] = `
         <dt
           class="euiDescriptionList__title"
         >
-          Port
+          Type
         </dt>
         <dd
           class="euiDescriptionList__description"
         >
-          23
+          HTTPS
         </dd>
       </dl>
     </div>

--- a/dashboards-notifications/public/pages/Channels/components/details/ChannelSettingsDetails.tsx
+++ b/dashboards-notifications/public/pages/Channels/components/details/ChannelSettingsDetails.tsx
@@ -168,6 +168,14 @@ export function ChannelSettingsDetails(props: ChannelSettingsDetailsProps) {
           description: CHANNEL_TYPE.webhook,
         },
         {
+          title: 'Method',
+          description: webhookObject.webhookMethod || '-',
+        },
+        {
+          title: 'Type',
+          description: webhookObject.customURLType || '-',
+        },
+        {
           title: 'Host',
           description: webhookObject.customURLHost || '-',
         },

--- a/dashboards-notifications/public/pages/Channels/types.ts
+++ b/dashboards-notifications/public/pages/Channels/types.ts
@@ -34,7 +34,9 @@ export interface HeaderItemType {
   value: string;
 }
 
-export type MethodType = 'POST' | 'PUT' | 'PATCH';
+export type WebhookMethodType = 'POST' | 'PUT' | 'PATCH';
+
+export type WebhookHttpType = 'HTTP' | 'HTTPS';
 
 export interface ChannelFiltersType {
   state?: string;

--- a/dashboards-notifications/public/pages/Channels/types.ts
+++ b/dashboards-notifications/public/pages/Channels/types.ts
@@ -34,6 +34,8 @@ export interface HeaderItemType {
   value: string;
 }
 
+export type MethodType = 'POST' | 'PUT' | 'PATCH';
+
 export interface ChannelFiltersType {
   state?: string;
   type?: string[];

--- a/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
@@ -53,7 +53,7 @@ import {
   ROUTES,
 } from '../../utils/constants';
 import { getErrorMessage } from '../../utils/helpers';
-import { HeaderItemType, MethodType } from '../Channels/types';
+import { HeaderItemType, WebhookHttpType, WebhookMethodType } from '../Channels/types';
 import { MainContext } from '../Main/Main';
 import { ChannelAvailabilityPanel } from './components/ChannelAvailabilityPanel';
 import { ChannelNamePanel } from './components/ChannelNamePanel';
@@ -136,10 +136,11 @@ export function CreateChannel(props: CreateChannelsProps) {
     keyof typeof CUSTOM_WEBHOOK_ENDPOINT_TYPE
   >('WEBHOOK_URL');
   const [webhookURL, setWebhookURL] = useState('');
+  const [customURLType, setCustomURLType] = useState<WebhookHttpType>('HTTPS');
   const [customURLHost, setCustomURLHost] = useState('');
   const [customURLPort, setCustomURLPort] = useState('');
   const [customURLPath, setCustomURLPath] = useState('');
-  const [webhookMethod, setWebhookMethod] = useState<MethodType>('POST');
+  const [webhookMethod, setWebhookMethod] = useState<WebhookMethodType>('POST');
   const [webhookParams, setWebhookParams] = useState<HeaderItemType[]>([]);
   const [webhookHeaders, setWebhookHeaders] = useState<HeaderItemType[]>([
     { key: 'Content-Type', value: 'application/json' },
@@ -310,6 +311,7 @@ export function CreateChannel(props: CreateChannelsProps) {
       config.webhook = constructWebhookObject(
         webhookTypeIdSelected,
         webhookURL,
+        customURLType,
         customURLHost,
         customURLPort,
         customURLPath,
@@ -456,6 +458,8 @@ export function CreateChannel(props: CreateChannelsProps) {
               setWebhookTypeIdSelected={setWebhookTypeIdSelected}
               webhookURL={webhookURL}
               setWebhookURL={setWebhookURL}
+              customURLType={customURLType}
+              setCustomURLType={setCustomURLType}
               customURLHost={customURLHost}
               setCustomURLHost={setCustomURLHost}
               customURLPort={customURLPort}

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
@@ -13,53 +13,62 @@ exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
       class="euiFormLabel euiFormRow__label"
       for="random_html_id"
     >
-      Define endpoints by
+      Method
     </label>
   </div>
   <div
     class="euiFormRow__fieldWrapper"
   >
     <div
-      id="random_html_id"
+      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
     >
       <div
-        class="euiRadio euiRadioGroup__item"
+        class="euiPopover__anchor"
       >
         <input
-          class="euiRadio__input"
-          id="WEBHOOK_URL"
-          type="radio"
+          id="random_html_id"
+          type="hidden"
           value=""
         />
         <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="WEBHOOK_URL"
+          class="euiFormControlLayout"
         >
-          Webhook URL
-        </label>
-      </div>
-      <div
-        class="euiRadio euiRadioGroup__item"
-      >
-        <input
-          checked=""
-          class="euiRadio__input"
-          id="CUSTOM_URL"
-          type="radio"
-          value=""
-        />
-        <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="CUSTOM_URL"
-        >
-          Custom attributes URL with HTTPS
-        </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <span
+              class="euiScreenReaderOnly"
+              id="random_html_id"
+            >
+              Select an option: 
+              , is selected
+            </span>
+            <button
+              aria-haspopup="true"
+              aria-labelledby="random_html_id random_html_id"
+              class="euiSuperSelectControl"
+              type="button"
+            />
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -79,53 +88,62 @@ exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
       class="euiFormLabel euiFormRow__label"
       for="random_html_id"
     >
-      Define endpoints by
+      Method
     </label>
   </div>
   <div
     class="euiFormRow__fieldWrapper"
   >
     <div
-      id="random_html_id"
+      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
     >
       <div
-        class="euiRadio euiRadioGroup__item"
+        class="euiPopover__anchor"
       >
         <input
-          checked=""
-          class="euiRadio__input"
-          id="WEBHOOK_URL"
-          type="radio"
+          id="random_html_id"
+          type="hidden"
           value=""
         />
         <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="WEBHOOK_URL"
+          class="euiFormControlLayout"
         >
-          Webhook URL
-        </label>
-      </div>
-      <div
-        class="euiRadio euiRadioGroup__item"
-      >
-        <input
-          class="euiRadio__input"
-          id="CUSTOM_URL"
-          type="radio"
-          value=""
-        />
-        <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="CUSTOM_URL"
-        >
-          Custom attributes URL with HTTPS
-        </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <span
+              class="euiScreenReaderOnly"
+              id="random_html_id"
+            >
+              Select an option: 
+              , is selected
+            </span>
+            <button
+              aria-haspopup="true"
+              aria-labelledby="random_html_id random_html_id"
+              class="euiSuperSelectControl"
+              type="button"
+            />
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -145,53 +163,67 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = 
       class="euiFormLabel euiFormRow__label"
       for="random_html_id"
     >
-      Define endpoints by
+      Method
     </label>
   </div>
   <div
     class="euiFormRow__fieldWrapper"
   >
     <div
-      id="random_html_id"
+      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
     >
       <div
-        class="euiRadio euiRadioGroup__item"
+        class="euiPopover__anchor"
       >
         <input
-          class="euiRadio__input"
-          id="WEBHOOK_URL"
-          type="radio"
+          id="random_html_id"
+          type="hidden"
           value=""
         />
         <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="WEBHOOK_URL"
+          class="euiFormControlLayout"
         >
-          Webhook URL
-        </label>
-      </div>
-      <div
-        class="euiRadio euiRadioGroup__item"
-      >
-        <input
-          checked=""
-          class="euiRadio__input"
-          id="CUSTOM_URL"
-          type="radio"
-          value=""
-        />
-        <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="CUSTOM_URL"
-        >
-          Custom attributes URL with HTTPS
-        </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <span
+              class="euiScreenReaderOnly"
+              id="random_html_id"
+            >
+              Select an option: 
+              , is selected
+            </span>
+            <button
+              aria-haspopup="true"
+              aria-labelledby="random_html_id random_html_id"
+              class="euiSuperSelectControl"
+              type="button"
+            />
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                    fill-rule="non-zero"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -211,53 +243,67 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 2`] = 
       class="euiFormLabel euiFormRow__label"
       for="random_html_id"
     >
-      Define endpoints by
+      Method
     </label>
   </div>
   <div
     class="euiFormRow__fieldWrapper"
   >
     <div
-      id="random_html_id"
+      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
     >
       <div
-        class="euiRadio euiRadioGroup__item"
+        class="euiPopover__anchor"
       >
         <input
-          checked=""
-          class="euiRadio__input"
-          id="WEBHOOK_URL"
-          type="radio"
+          id="random_html_id"
+          type="hidden"
           value=""
         />
         <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="WEBHOOK_URL"
+          class="euiFormControlLayout"
         >
-          Webhook URL
-        </label>
-      </div>
-      <div
-        class="euiRadio euiRadioGroup__item"
-      >
-        <input
-          class="euiRadio__input"
-          id="CUSTOM_URL"
-          type="radio"
-          value=""
-        />
-        <div
-          class="euiRadio__circle"
-        />
-        <label
-          class="euiRadio__label"
-          for="CUSTOM_URL"
-        >
-          Custom attributes URL with HTTPS
-        </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <span
+              class="euiScreenReaderOnly"
+              id="random_html_id"
+            >
+              Select an option: 
+              , is selected
+            </span>
+            <button
+              aria-haspopup="true"
+              aria-labelledby="random_html_id random_html_id"
+              class="euiSuperSelectControl"
+              type="button"
+            />
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                class="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                    fill-rule="non-zero"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
@@ -9,6 +9,7 @@
  * GitHub history for details.
  */
 
+import { ChannelItemType } from '../../../../models/interfaces';
 import {
   constructEmailObject,
   constructWebhookObject,
@@ -22,6 +23,7 @@ describe('constructs and deconstructs webhook objects', () => {
     'test-webhook.com',
     '1234',
     'subdirectory',
+    'POST',
     [
       { key: 'param1', value: 'value1' },
       { key: 'param2', value: '' },
@@ -37,10 +39,11 @@ describe('constructs and deconstructs webhook objects', () => {
       { key: 'header3', value: 'value3' },
     ],
   ];
-  const webhookItem = {
+  const webhookItem: ChannelItemType['webhook'] = {
     url:
       'https://test-webhook.com:1234/subdirectory?param1=value1&param2=&param3=value3',
     header_params: { header1: 'value1', header2: '', header3: 'value3' },
+    method: 'POST',
   };
 
   it('constructs webhook objects', () => {
@@ -60,12 +63,14 @@ describe('constructs and deconstructs webhook objects', () => {
       'test-webhook.com',
       '',
       '',
+      'POST',
       [],
       []
     );
     expect(resultFromCustomURL).toEqual({
       url: 'https://test-webhook.com',
       header_params: {},
+      method: 'POST',
     });
   });
 
@@ -104,7 +109,11 @@ describe('constructs and deconstructs webhook objects', () => {
       customURLPath,
       webhookParams,
       webhookHeaders,
-    } = deconstructWebhookObject({ url: 'invalid url', header_params: {} });
+    } = deconstructWebhookObject({
+      url: 'invalid url',
+      header_params: {},
+      method: 'POST',
+    });
     expect(webhookURL).toEqual('invalid url');
     expect(customURLHost).toEqual('');
     expect(customURLPort).toEqual('');

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
@@ -20,6 +20,7 @@ import {
 describe('constructs and deconstructs webhook objects', () => {
   const args = [
     'https://test-webhook.com:1234/subdirectory?param1=value1&param2=&param3=value3',
+    'HTTPS',
     'test-webhook.com',
     '1234',
     'subdirectory',
@@ -60,6 +61,7 @@ describe('constructs and deconstructs webhook objects', () => {
     const resultFromCustomURL = constructWebhookObject(
       'CUSTOM_URL',
       '',
+      'HTTPS',
       'test-webhook.com',
       '',
       '',
@@ -77,6 +79,7 @@ describe('constructs and deconstructs webhook objects', () => {
   it('deconstructs webhook objects', () => {
     const {
       webhookURL,
+      customURLType,
       customURLHost,
       customURLPort,
       customURLPath,
@@ -84,9 +87,10 @@ describe('constructs and deconstructs webhook objects', () => {
       webhookHeaders,
     } = deconstructWebhookObject(webhookItem);
     expect(webhookURL).toEqual(args[0]);
-    expect(customURLHost).toEqual(args[1]);
-    expect(customURLPort).toEqual(args[2]);
-    expect(customURLPath).toEqual(args[3]);
+    expect(customURLType).toEqual(args[1]);
+    expect(customURLHost).toEqual(args[2]);
+    expect(customURLPort).toEqual(args[3]);
+    expect(customURLPath).toEqual(args[4]);
     expect(webhookParams).toEqual([
       { key: 'param1', value: 'value1' },
       { key: 'param2', value: '' },

--- a/dashboards-notifications/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -31,10 +31,11 @@ import {
   EuiRadioGroup,
   EuiRadioGroupOption,
   EuiSpacer,
+  EuiSuperSelect,
 } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CUSTOM_WEBHOOK_ENDPOINT_TYPE } from '../../../utils/constants';
-import { HeaderItemType } from '../../Channels/types';
+import { HeaderItemType, MethodType } from '../../Channels/types';
 import { CreateChannelContext } from '../CreateChannel';
 import {
   validateCustomURLHost,
@@ -56,6 +57,8 @@ interface CustomWebhookSettingsProps {
   setCustomURLPort: (customURLPort: string) => void;
   customURLPath: string;
   setCustomURLPath: (customURLPath: string) => void;
+  webhookMethod: MethodType;
+  setWebhookMethod: (webhookMethod: MethodType) => void;
   webhookParams: HeaderItemType[];
   setWebhookParams: (webhookParams: HeaderItemType[]) => void;
   webhookHeaders: HeaderItemType[];
@@ -167,6 +170,27 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
 
   return (
     <>
+      <EuiFormRow label="Method" style={{ maxWidth: '700px' }}>
+        <EuiSuperSelect
+          options={[
+            {
+              value: 'POST',
+              inputDisplay: 'POST',
+            },
+            {
+              value: 'PUT',
+              inputDisplay: 'PUT',
+            },
+            {
+              value: 'PATCH',
+              inputDisplay: 'PATCH',
+            },
+          ]}
+          valueOfSelected={props.webhookMethod}
+          onChange={props.setWebhookMethod}
+        />
+      </EuiFormRow>
+
       <EuiFormRow label="Define endpoints by" style={{ maxWidth: '700px' }}>
         <EuiRadioGroup
           options={webhookTypeOptions}

--- a/dashboards-notifications/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -35,7 +35,11 @@ import {
 } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CUSTOM_WEBHOOK_ENDPOINT_TYPE } from '../../../utils/constants';
-import { HeaderItemType, MethodType } from '../../Channels/types';
+import {
+  HeaderItemType,
+  WebhookHttpType,
+  WebhookMethodType,
+} from '../../Channels/types';
 import { CreateChannelContext } from '../CreateChannel';
 import {
   validateCustomURLHost,
@@ -51,14 +55,16 @@ interface CustomWebhookSettingsProps {
   ) => void;
   webhookURL: string;
   setWebhookURL: (webhookURL: string) => void;
+  customURLType: WebhookHttpType;
+  setCustomURLType: (customURLType: WebhookHttpType) => void;
   customURLHost: string;
   setCustomURLHost: (customURLHost: string) => void;
   customURLPort: string;
   setCustomURLPort: (customURLPort: string) => void;
   customURLPath: string;
   setCustomURLPath: (customURLPath: string) => void;
-  webhookMethod: MethodType;
-  setWebhookMethod: (webhookMethod: MethodType) => void;
+  webhookMethod: WebhookMethodType;
+  setWebhookMethod: (webhookMethod: WebhookMethodType) => void;
   webhookParams: HeaderItemType[];
   setWebhookParams: (webhookParams: HeaderItemType[]) => void;
   webhookHeaders: HeaderItemType[];
@@ -101,6 +107,16 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
   const renderCustomURL = () => {
     return (
       <>
+        <EuiFormRow label="Type">
+          <EuiSuperSelect
+            options={[
+              { value: 'HTTPS', inputDisplay: 'HTTPS' },
+              { value: 'HTTP', inputDisplay: 'HTTP' },
+            ]}
+            valueOfSelected={props.customURLType}
+            onChange={props.setCustomURLType}
+          />
+        </EuiFormRow>
         <EuiFormRow
           label="Host"
           error={context.inputErrors.customURLHost.join(' ')}
@@ -173,18 +189,9 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
       <EuiFormRow label="Method" style={{ maxWidth: '700px' }}>
         <EuiSuperSelect
           options={[
-            {
-              value: 'POST',
-              inputDisplay: 'POST',
-            },
-            {
-              value: 'PUT',
-              inputDisplay: 'PUT',
-            },
-            {
-              value: 'PATCH',
-              inputDisplay: 'PATCH',
-            },
+            { value: 'POST', inputDisplay: 'POST' },
+            { value: 'PUT', inputDisplay: 'PUT' },
+            { value: 'PATCH', inputDisplay: 'PATCH' },
           ]}
           valueOfSelected={props.webhookMethod}
           onChange={props.setWebhookMethod}

--- a/dashboards-notifications/public/pages/CreateChannel/utils/helper.ts
+++ b/dashboards-notifications/public/pages/CreateChannel/utils/helper.ts
@@ -13,7 +13,7 @@ import { EuiComboBoxOptionOption } from '@elastic/eui';
 import _ from 'lodash';
 import { ChannelItemType, SenderType } from '../../../../models/interfaces';
 import { CUSTOM_WEBHOOK_ENDPOINT_TYPE } from '../../../utils/constants';
-import { HeaderItemType } from '../../Channels/types';
+import { HeaderItemType, MethodType } from '../../Channels/types';
 
 export const constructWebhookObject = (
   webhookTypeIdSelected: keyof typeof CUSTOM_WEBHOOK_ENDPOINT_TYPE,
@@ -21,6 +21,7 @@ export const constructWebhookObject = (
   customURLHost: string,
   customURLPort: string,
   customURLPath: string,
+  webhookMethod: MethodType,
   webhookParams: HeaderItemType[],
   webhookHeaders: HeaderItemType[]
 ) => {
@@ -43,7 +44,7 @@ export const constructWebhookObject = (
   const header_params = webhookHeaders
     .filter(({ key, value }) => key)
     .reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {});
-  return { url, header_params };
+  return { url, header_params, method: webhookMethod };
 };
 
 export const deconstructWebhookObject = (
@@ -53,6 +54,7 @@ export const deconstructWebhookObject = (
   customURLHost: string;
   customURLPort: string;
   customURLPath: string;
+  webhookMethod: MethodType;
   webhookParams: HeaderItemType[];
   webhookHeaders: HeaderItemType[];
 } => {
@@ -73,6 +75,7 @@ export const deconstructWebhookObject = (
       customURLHost,
       customURLPort,
       customURLPath,
+      webhookMethod: webhook.method as MethodType,
       webhookParams,
       webhookHeaders,
     };
@@ -83,6 +86,7 @@ export const deconstructWebhookObject = (
       customURLHost: '',
       customURLPort: '',
       customURLPath: '',
+      webhookMethod: 'POST',
       webhookParams: [],
       webhookHeaders: [],
     };

--- a/dashboards-notifications/public/utils/constants.ts
+++ b/dashboards-notifications/public/utils/constants.ts
@@ -113,7 +113,7 @@ export const SEVERITY_TYPE = Object.freeze({
 
 export const CUSTOM_WEBHOOK_ENDPOINT_TYPE = Object.freeze({
   WEBHOOK_URL: 'Webhook URL',
-  CUSTOM_URL: 'Custom attributes URL with HTTPS',
+  CUSTOM_URL: 'Custom attributes URL',
 });
 
 export const HISTOGRAM_TYPE = Object.freeze({

--- a/dashboards-notifications/test/mocks/mockData.ts
+++ b/dashboards-notifications/test/mocks/mockData.ts
@@ -105,7 +105,7 @@ const mockEmailWithSES: ChannelItemType = {
       'qQ_8gUxOPmIl9Il-5fv0': 'name5',
       '52KTe3xOdSwJeziY43zi': 'name6',
     },
-    invalid_ids: ["52KTe3xOdSwJeziY43zi"],
+    invalid_ids: ['52KTe3xOdSwJeziY43zi'],
     sender_type: 'ses_account',
   },
   config_id: 'QZT3mKxOCn6LSkzIsAzz',
@@ -129,6 +129,7 @@ const mockWebhook: ChannelItemType = {
       key5: 'value5',
       key6: 'value6',
     },
+    method: 'POST',
   },
   config_id: '7mUjsHkBqFjWrmvLc3nl',
   created_time_ms: 1622157784037,
@@ -242,7 +243,14 @@ const mockNotification: NotificationItem = {
 
 export const MOCK_DATA = {
   channels: {
-    items: [mockChime, mockSlack, mockEmail, mockEmailWithSES, mockWebhook, mockSNS],
+    items: [
+      mockChime,
+      mockSlack,
+      mockEmail,
+      mockEmailWithSES,
+      mockWebhook,
+      mockSNS,
+    ],
     total: 6,
   },
   chime: mockChime,


### PR DESCRIPTION
### Description
add ui to select method (POST, PUT, PATCH) and type (HTTPS, HTTP) for custom webhook
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
