### PR TITLE
Frontend: fix parsing date string to timestamp

### DIFF
--- a/dashboards-notifications/public/pages/Notifications/containers/Notifications.tsx
+++ b/dashboards-notifications/public/pages/Notifications/containers/Notifications.tsx
@@ -180,7 +180,9 @@ export default class Notifications extends Component<
       sort_order: state.sortDirection,
       last_updated_time_ms: `${dateMath
         .parse(state.startTime)
-        ?.valueOf()}..${dateMath.parse(state.endTime)?.valueOf()}`,
+        ?.valueOf()}..${dateMath
+        .parse(state.endTime, { roundUp: true })
+        ?.valueOf()}`,
       ...filterParams,
     };
   }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Selecting a date range like "Today" in date picker will set both start time and end time to the same string `now/d`, which breaks timestamp parsing. So rounding up the end time calculation to include the whole time range
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
