### PR TITLE
Remove features and feature_list usage in Notifications

### DIFF
--- a/dashboards-notifications/models/interfaces.ts
+++ b/dashboards-notifications/models/interfaces.ts
@@ -8,7 +8,6 @@ import { WebhookMethodType } from '../public/pages/Channels/types';
 import {
   CHANNEL_TYPE,
   ENCRYPTION_TYPE,
-  NOTIFICATION_SOURCE,
 } from '../public/utils/constants';
 
 export interface ChannelStatus {
@@ -31,7 +30,6 @@ export type SenderType = 'smtp_account' | 'ses_account';
 
 export interface ChannelItemType extends ConfigType {
   config_type: keyof typeof CHANNEL_TYPE;
-  feature_list: Array<keyof typeof NOTIFICATION_SOURCE>;
   is_enabled: boolean; // active or muted
   slack?: {
     url: string;

--- a/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
+++ b/dashboards-notifications/public/pages/Channels/components/details/ChannelDetailsActions.tsx
@@ -41,7 +41,6 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
     try {
       await servicesContext.notificationService.sendTestMessage(
         props.channel.config_id,
-        props.channel.feature_list[0]
       );
       coreContext.notifications.toasts.addSuccess(
         'Successfully sent a test message.'
@@ -62,7 +61,6 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
     {
       label: 'Send test message',
       disabled:
-        props.channel.feature_list.length === 0 ||
         !props.channel.config_id ||
         !props.channel.is_enabled,
       action: sendTestMessage,

--- a/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
+++ b/dashboards-notifications/public/pages/CreateChannel/CreateChannel.tsx
@@ -264,7 +264,6 @@ export function CreateChannel(props: CreateChannelsProps) {
       name,
       description,
       config_type: channelType,
-      feature_list: ['alerting'], // TODO: Remove this from config when the backend no longer requires it
       is_enabled: isEnabled,
     };
     if (channelType === BACKEND_CHANNEL_TYPE.SLACK) {
@@ -327,7 +326,6 @@ export function CreateChannel(props: CreateChannelsProps) {
 
       await servicesContext.notificationService.sendTestMessage(
         tempChannelId,
-        config.feature_list[0] // for test message any source works
       );
       coreContext.notifications.toasts.addSuccess(
         'Successfully sent a test message.'

--- a/dashboards-notifications/public/pages/Emails/__tests__/helper.test.ts
+++ b/dashboards-notifications/public/pages/Emails/__tests__/helper.test.ts
@@ -21,7 +21,6 @@ describe('creates sender and recipient groups as config object', () => {
     expect(config).toEqual({
       name: 'sender',
       config_type: 'smtp_account',
-      feature_list: ['alerting', 'index_management', 'reports'],
       is_enabled: true,
       smtp_account: {
         host: 'test.com',
@@ -52,7 +51,6 @@ describe('creates sender and recipient groups as config object', () => {
       name: 'recipient group',
       config_type: 'email_group',
       description: 'test description',
-      feature_list: ['alerting', 'index_management', 'reports'],
       is_enabled: true,
       email_group: {
         recipient_list: [

--- a/dashboards-notifications/public/pages/Emails/utils/helper.ts
+++ b/dashboards-notifications/public/pages/Emails/utils/helper.ts
@@ -4,7 +4,7 @@
  */
 
 import { EuiComboBoxOptionOption } from '@elastic/eui';
-import { ENCRYPTION_TYPE, NOTIFICATION_SOURCE } from '../../../utils/constants';
+import { ENCRYPTION_TYPE } from '../../../utils/constants';
 
 export const createSenderConfigObject = (
   senderName: string,
@@ -16,7 +16,6 @@ export const createSenderConfigObject = (
   return {
     name: senderName,
     config_type: 'smtp_account',
-    feature_list: Object.keys(NOTIFICATION_SOURCE),
     is_enabled: true,
     smtp_account: {
       host,
@@ -36,7 +35,6 @@ export const createSesSenderConfigObject = (
   return {
     name: senderName,
     config_type: 'ses_account',
-    feature_list: Object.keys(NOTIFICATION_SOURCE),
     is_enabled: true,
     ses_account: {
       from_address: email,
@@ -55,7 +53,6 @@ export const createRecipientGroupConfigObject = (
     name,
     description,
     config_type: 'email_group',
-    feature_list: Object.keys(NOTIFICATION_SOURCE),
     is_enabled: true,
     email_group: {
       recipient_list: selectedEmailOptions.map((email) => ({

--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -14,7 +14,7 @@ import {
   SenderType,
   SESSenderItemType,
 } from '../../models/interfaces';
-import {CHANNEL_TYPE, NOTIFICATION_SOURCE} from '../utils/constants';
+import { CHANNEL_TYPE } from '../utils/constants';
 import {
   configListToChannels,
   configListToRecipientGroups,
@@ -244,16 +244,10 @@ export default class NotificationService {
   };
 
   sendTestMessage = async (
-      configId: string,
-      feature: keyof typeof NOTIFICATION_SOURCE
+      configId: string
   ) => {
     const response = await this.httpClient.get(
-        `${NODE_API.SEND_TEST_MESSAGE}/${configId}`,
-        {
-          query: {
-            feature,
-          },
-        }
+        `${NODE_API.SEND_TEST_MESSAGE}/${configId}`
     );
     if (response.event_id != null) {
       await this.getNotification(response.event_id).then((response) => {

--- a/dashboards-notifications/public/utils/constants.ts
+++ b/dashboards-notifications/public/utils/constants.ts
@@ -48,12 +48,6 @@ export const BREADCRUMBS = Object.freeze({
   EDIT_RECIPIENT_GROUP: { text: 'Edit recipient group' },
 });
 
-export const NOTIFICATION_SOURCE = Object.freeze({
-  alerting: 'Alerting',
-  index_management: 'ISM',
-  reports: 'Reporting',
-});
-
 export const BACKEND_CHANNEL_TYPE = Object.freeze({
   SLACK: 'slack',
   EMAIL: 'email',

--- a/dashboards-notifications/server/routes/configRoutes.ts
+++ b/dashboards-notifications/server/routes/configRoutes.ts
@@ -24,9 +24,6 @@ export function configRoutes(router: IRouter) {
             schema.arrayOf(schema.string()),
             schema.string(),
           ]),
-          feature_list: schema.maybe(
-            schema.oneOf([schema.arrayOf(schema.string()), schema.string()])
-          ),
           is_enabled: schema.maybe(schema.boolean()),
           sort_field: schema.string(),
           sort_order: schema.string(),
@@ -41,7 +38,6 @@ export function configRoutes(router: IRouter) {
     },
     async (context, request, response) => {
       const config_type = joinRequestParams(request.query.config_type);
-      const feature_list = joinRequestParams(request.query.feature_list);
       const config_id_list = joinRequestParams(request.query.config_id_list);
       const encryption_method = joinRequestParams(
         request.query['smtp_account.method']
@@ -61,7 +57,6 @@ export function configRoutes(router: IRouter) {
             sort_field: request.query.sort_field,
             sort_order: request.query.sort_order,
             config_type,
-            ...(feature_list && { feature_list }),
             ...(query && { text_query: query }), // text_query will exclude keyword fields
             ...(config_id_list && { config_id_list }),
             ...(encryption_method && {

--- a/dashboards-notifications/server/routes/eventRoutes.ts
+++ b/dashboards-notifications/server/routes/eventRoutes.ts
@@ -47,9 +47,6 @@ export function eventRoutes(router: IRouter) {
         params: schema.object({
           configId: schema.string(),
         }),
-        query: schema.object({
-          feature: schema.string(),
-        }),
       },
     },
     async (context, request, response) => {
@@ -62,7 +59,6 @@ export function eventRoutes(router: IRouter) {
           'notifications.sendTestMessage',
           {
             configId: request.params.configId,
-            feature: request.query.feature,
           }
         );
         return response.ok({ body: resp });

--- a/dashboards-notifications/test/mocks/mockData.ts
+++ b/dashboards-notifications/test/mocks/mockData.ts
@@ -14,7 +14,6 @@ const mockChime: ChannelItemType = {
   name: 'Chime test channel',
   description: 'test description',
   config_type: 'chime',
-  feature_list: ['reports'],
   is_enabled: true,
   chime: {
     url: 'https://chimehook',
@@ -28,7 +27,6 @@ const mockSlack: ChannelItemType = {
   name: 'Slack test channel',
   description: 'test description',
   config_type: 'slack',
-  feature_list: ['reports'],
   is_enabled: false,
   slack: {
     url: 'https://chimehook',
@@ -42,7 +40,6 @@ const mockEmail: ChannelItemType = {
   name: 'Email test channel',
   description: 'test description',
   config_type: 'email',
-  feature_list: ['alerting'],
   is_enabled: true,
   email: {
     email_account_id: 'dj8etXkBCzVy9Vy-nsiL',
@@ -76,7 +73,6 @@ const mockEmailWithSES: ChannelItemType = {
   name: 'Email test channel',
   description: 'test description',
   config_type: 'email',
-  feature_list: ['alerting'],
   is_enabled: true,
   email: {
     email_account_id: 'dj8etXkBCzVy9Vy-nsiL',
@@ -110,7 +106,6 @@ const mockWebhook: ChannelItemType = {
   name: 'Webhook test channel',
   description: 'test description',
   config_type: 'webhook',
-  feature_list: ['alerting'],
   is_enabled: true,
   webhook: {
     url: 'https://host:23/path?key1=%23%404&key2=&key3=value3',
@@ -133,7 +128,6 @@ const mockSNS: ChannelItemType = {
   name: 'SNS test channel',
   description: 'test description',
   config_type: 'sns',
-  feature_list: ['alerting'],
   is_enabled: true,
   sns: {
     topic_arn: 'arn:aws:sns:us-west-2:012345678912:notifications-test',

--- a/notifications/build-tools/merged-coverage.gradle
+++ b/notifications/build-tools/merged-coverage.gradle
@@ -5,7 +5,7 @@
 
 allprojects {
     plugins.withId('jacoco') {
-        jacoco.toolVersion = '0.8.5'
+        jacoco.toolVersion = '0.8.7'
         // For some reason this dependency isn't getting setup automatically by the jacoco plugin
         tasks.withType(JacocoReport) { 
             dependsOn tasks.withType(Test)

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        kotlin_version = System.getProperty("kotlin.version", "1.4.32")
+        kotlin_version = System.getProperty("kotlin.version", "1.6.10")
         junit_version = System.getProperty("junit.version", "5.7.2")
         aws_version = System.getProperty("aws.version", "1.12.48")
     }
@@ -55,10 +55,10 @@ allprojects {
     }
     group = "org.opensearch"
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "1.8"
+        sourceCompatibility = targetCompatibility = "11"
     }
     plugins.withId('org.jetbrains.kotlin.jvm') {
-        compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = "1.8"
+        compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = "11"
         compileKotlin.dependsOn ktlint
     }
 }
@@ -68,7 +68,7 @@ configurations {
 }
 
 dependencies {
-    add("ktlint", "com.pinterest:ktlint:0.41.0") {
+    add("ktlint", "com.pinterest:ktlint:0.44.0") {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
         }

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -46,7 +46,10 @@ dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-    compile "com.amazonaws:aws-java-sdk-ses:${aws_version}"
+    implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
+    implementation "com.amazonaws:aws-java-sdk-ses:${aws_version}"
+    implementation "org.apache.httpcomponents:httpcore:4.4.13"
+    implementation "org.apache.httpcomponents:httpclient:4.5.10"
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation(
@@ -54,9 +57,9 @@ dependencies {
             "org.junit.jupiter:junit-jupiter-params:5.6.2",
             'org.mockito:mockito-junit-jupiter:3.10.0',
     )
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
-    testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testCompile "org.opensearch.test:framework:${opensearch_version}"
+    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
+    testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 
 configurations.all {

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -100,10 +100,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.apache.httpcomponents:httpcore:4.4.5"
     implementation "org.apache.httpcomponents:httpclient:4.5.10"
+    implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sts:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-ses:${aws_version}"
     implementation "com.sun.mail:javax.mail:1.6.2"
+    implementation "javax.activation:activation:1.1"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',
@@ -124,6 +126,7 @@ dependencies {
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
     testImplementation "org.mockito:mockito-core:4.3.1"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -96,14 +96,14 @@ compileKotlin { kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict'] }
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-    compile "org.apache.httpcomponents:httpcore:4.4.5"
-    compile "org.apache.httpcomponents:httpclient:4.5.10"
-    compile "com.amazonaws:aws-java-sdk-sns:${aws_version}"
-    compile "com.amazonaws:aws-java-sdk-sts:${aws_version}"
-    compile "com.amazonaws:aws-java-sdk-ses:${aws_version}"
-    compile "com.sun.mail:javax.mail:1.6.2"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
+    implementation "org.apache.httpcomponents:httpcore:4.4.5"
+    implementation "org.apache.httpcomponents:httpclient:4.5.10"
+    implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"
+    implementation "com.amazonaws:aws-java-sdk-sts:${aws_version}"
+    implementation "com.amazonaws:aws-java-sdk-ses:${aws_version}"
+    implementation "com.sun.mail:javax.mail:1.6.2"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',
@@ -122,16 +122,16 @@ dependencies {
     )
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
-    testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testCompile "org.mockito:mockito-core:4.3.1"
-    testCompile "org.opensearch.test:framework:${opensearch_version}"
-    testCompile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
-    compile project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')
+    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
+    testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
+    implementation project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')
 }
 
 configurations {
-    testCompile {
+    testImplementation {
         exclude group: 'org.elasticsearch', module: 'securemock' // resolve jarhell with mockito
     }
 }

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -43,7 +43,7 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 }
 
-configurations.testCompile {
+configurations.testImplementation {
     exclude module: "securemock"
 }
 
@@ -58,12 +58,12 @@ configurations.all {
 dependencies {
     compileOnly "${group}:opensearch:${opensearch_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-    compile ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3") {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3") {
         exclude group: 'org.jetbrains', module: 'annotations' // resolve jarhell
     } // ${kotlin_version} does not work for coroutines
-    compile "${group}:common-utils:${common_utils_version}"
-    compile "org.json:json:20180813"
+    implementation "${group}:common-utils:${common_utils_version}"
+    implementation "org.json:json:20180813"
 
     testImplementation(
             'org.assertj:assertj-core:3.19.0',
@@ -79,14 +79,14 @@ dependencies {
             "org.junit.jupiter:junit-jupiter-api:${junit_version}"
     )
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junit_version}")
-    testCompile "org.opensearch.test:framework:${opensearch_version}"
-    testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
-    testCompile "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
-    testCompile "org.mockito:mockito-core:4.3.1"
-    testCompile 'com.google.code.gson:gson:2.8.7'
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
+    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation 'com.google.code.gson:gson:2.8.7'
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
-    compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
     compileOnly project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')
 }
 

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
+    testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
     testImplementation "org.mockito:mockito-core:4.3.1"
     testImplementation 'com.google.code.gson:gson:2.8.7'
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetFeatureChannelListAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetFeatureChannelListAction.kt
@@ -9,7 +9,6 @@ import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
-import org.opensearch.common.Strings
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
@@ -18,7 +17,6 @@ import org.opensearch.commons.notifications.action.GetFeatureChannelListResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.notifications.index.ConfigIndexingActions
-import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 
@@ -59,10 +57,6 @@ internal class GetFeatureChannelListAction @Inject constructor(
         request: GetFeatureChannelListRequest,
         user: User?
     ): GetFeatureChannelListResponse {
-        require(!Strings.isNullOrEmpty(request.feature)) {
-            Metrics.NOTIFICATIONS_FEATURE_CHANNELS_INFO_USER_ERROR_INVALID_FEATURE_TAG.counter.increment()
-            "Not a valid feature"
-        } // TODO: Validate against allowed features
         return ConfigIndexingActions.getFeatureChannelList(request, user)
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendTestNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendTestNotificationAction.kt
@@ -50,8 +50,8 @@ internal class SendTestNotificationAction @Inject constructor(
         request: SendTestNotificationRequest,
         listener: ActionListener<SendNotificationResponse>
     ) {
-        val source = SendTestNotificationActionHelper.generateEventSource(request.feature, request.configId)
-        val message = SendTestNotificationActionHelper.generateMessage(request.feature, request.configId)
+        val source = SendTestNotificationActionHelper.generateEventSource(request.configId)
+        val message = SendTestNotificationActionHelper.generateMessage(request.configId)
         val channelIds = listOf(request.configId)
         NotificationsPluginInterface.sendNotification(
             client as NodeClient,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -130,7 +130,7 @@ object ConfigIndexingActions {
             }
             // Validate that the user has access to underlying configurations as well.
             val currentMetadata = it.configDoc.metadata
-            if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+            if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for NotificationConfig ${it.docInfo.id}",
@@ -241,7 +241,7 @@ object ConfigIndexingActions {
             }
 
         val currentMetadata = currentConfigDoc.configDoc.metadata
-        if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+        if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
                 "Permission denied for NotificationConfig ${request.configId}",
@@ -292,7 +292,7 @@ object ConfigIndexingActions {
                 throw OpenSearchStatusException("NotificationConfig $configId not found", RestStatus.NOT_FOUND)
             }
         val metadata = configDoc.configDoc.metadata
-        if (!userAccess.doesUserHasAccess(user, metadata.access)) {
+        if (!userAccess.doesUserHaveAccess(user, metadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for NotificationConfig $configId", RestStatus.FORBIDDEN)
         }
@@ -325,7 +325,7 @@ object ConfigIndexingActions {
         }
         configDocs.forEach {
             val currentMetadata = it.configDoc.metadata
-            if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+            if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for NotificationConfig ${it.docInfo.id}",
@@ -417,7 +417,7 @@ object ConfigIndexingActions {
             }
 
         val currentMetadata = currentConfigDoc.configDoc.metadata
-        if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+        if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
                 "Permission denied for NotificationConfig $configId",
@@ -455,7 +455,7 @@ object ConfigIndexingActions {
         }
         configDocs.forEach {
             val currentMetadata = it.configDoc.metadata
-            if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+            if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for NotificationConfig ${it.docInfo.id}",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -32,7 +32,6 @@ import org.opensearch.commons.notifications.model.SmtpAccount
 import org.opensearch.commons.notifications.model.Sns
 import org.opensearch.commons.notifications.model.Webhook
 import org.opensearch.commons.utils.logger
-import org.opensearch.notifications.CoreProvider
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
 import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.notifications.model.DocMetadata
@@ -76,7 +75,7 @@ object ConfigIndexingActions {
         // TODO: URL validation with rules
     }
 
-    private fun validateEmailConfig(email: Email, features: Set<String>, user: User?) {
+    private fun validateEmailConfig(email: Email, user: User?) {
         if (email.emailGroupIds.contains(email.emailAccountID)) {
             throw OpenSearchStatusException(
                 "Config IDs ${email.emailAccountID} is in both emailAccountID and emailGroupIds",
@@ -137,18 +136,6 @@ object ConfigIndexingActions {
                     RestStatus.FORBIDDEN
                 )
             }
-
-            // Validate the features enabled are included in all underlying configurations as well.
-            if (!it.configDoc.config.features.containsAll(features)) {
-                val missingFeatures = features.filterNot { item ->
-                    it.configDoc.config.features.contains(item)
-                }
-                Metrics.NOTIFICATIONS_SECURITY_USER_ERROR.counter.increment()
-                throw OpenSearchStatusException(
-                    "Some Features not available in NotificationConfig ${it.docInfo.id}:$missingFeatures",
-                    RestStatus.FORBIDDEN
-                )
-            }
         }
     }
 
@@ -168,14 +155,6 @@ object ConfigIndexingActions {
     }
 
     private fun validateConfig(config: NotificationConfig, user: User?) {
-        config.features.forEach {
-            if (!CoreProvider.core.getAllowedConfigFeatures().contains(it)) {
-                throw OpenSearchStatusException(
-                    "NotificationConfig with type feature $it is not acceptable",
-                    RestStatus.NOT_ACCEPTABLE
-                )
-            }
-        }
         when (config.configType) {
             ConfigType.NONE -> throw OpenSearchStatusException(
                 "NotificationConfig with type NONE is not acceptable",
@@ -184,7 +163,7 @@ object ConfigIndexingActions {
             ConfigType.SLACK -> validateSlackConfig(config.configData as Slack, user)
             ConfigType.CHIME -> validateChimeConfig(config.configData as Chime, user)
             ConfigType.WEBHOOK -> validateWebhookConfig(config.configData as Webhook, user)
-            ConfigType.EMAIL -> validateEmailConfig(config.configData as Email, config.features, user)
+            ConfigType.EMAIL -> validateEmailConfig(config.configData as Email, user)
             ConfigType.SMTP_ACCOUNT -> validateSmtpAccountConfig(config.configData as SmtpAccount, user)
             ConfigType.SES_ACCOUNT -> validateSesAccountConfig(config.configData as SesAccount, user)
             ConfigType.EMAIL_GROUP -> validateEmailGroupConfig(config.configData as EmailGroup, user)
@@ -370,7 +349,6 @@ object ConfigIndexingActions {
         userAccess.validateUser(user)
         val supportedChannelListString = getSupportedChannelList().joinToString(",")
         val filterParams = mapOf(
-            Pair("feature_list", request.feature),
             Pair("config_type", supportedChannelListString)
         )
         val getAllRequest = GetNotificationConfigRequest(filterParams = filterParams)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigQueryHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigQueryHelper.kt
@@ -12,7 +12,6 @@ import org.opensearch.commons.notifications.NotificationConstants.CREATED_TIME_T
 import org.opensearch.commons.notifications.NotificationConstants.DESCRIPTION_TAG
 import org.opensearch.commons.notifications.NotificationConstants.EMAIL_ACCOUNT_ID_TAG
 import org.opensearch.commons.notifications.NotificationConstants.EMAIL_GROUP_ID_LIST_TAG
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_LIST_TAG
 import org.opensearch.commons.notifications.NotificationConstants.FROM_ADDRESS_TAG
 import org.opensearch.commons.notifications.NotificationConstants.HOST_TAG
 import org.opensearch.commons.notifications.NotificationConstants.IS_ENABLED_TAG
@@ -61,7 +60,6 @@ object ConfigQueryHelper {
     )
     private val KEYWORD_FIELDS = setOf(
         CONFIG_TYPE_TAG,
-        FEATURE_LIST_TAG,
         "${EMAIL.tag}.$EMAIL_ACCOUNT_ID_TAG",
         "${EMAIL.tag}.$EMAIL_GROUP_ID_LIST_TAG",
         "${SMTP_ACCOUNT.tag}.$METHOD_TAG",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/EventIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/EventIndexingActions.kt
@@ -62,7 +62,7 @@ object EventIndexingActions {
                 throw OpenSearchStatusException("NotificationEvent $eventId not found", RestStatus.NOT_FOUND)
             }
         val metadata = eventDoc.eventDoc.metadata
-        if (!userAccess.doesUserHasAccess(user, metadata.access)) {
+        if (!userAccess.doesUserHaveAccess(user, metadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for NotificationEvent $eventId", RestStatus.FORBIDDEN)
         }
@@ -95,7 +95,7 @@ object EventIndexingActions {
         }
         eventDocs.forEach {
             val currentMetadata = it.eventDoc.metadata
-            if (!userAccess.doesUserHasAccess(user, currentMetadata.access)) {
+            if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for NotificationEvent ${it.docInfo.id}",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/EventQueryHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/EventQueryHelper.kt
@@ -14,7 +14,6 @@ import org.opensearch.commons.notifications.NotificationConstants.DELIVERY_STATU
 import org.opensearch.commons.notifications.NotificationConstants.EMAIL_RECIPIENT_STATUS_TAG
 import org.opensearch.commons.notifications.NotificationConstants.EVENT_SOURCE_TAG
 import org.opensearch.commons.notifications.NotificationConstants.EVENT_TAG
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_TAG
 import org.opensearch.commons.notifications.NotificationConstants.QUERY_TAG
 import org.opensearch.commons.notifications.NotificationConstants.RECIPIENT_TAG
 import org.opensearch.commons.notifications.NotificationConstants.REFERENCE_ID_TAG
@@ -46,7 +45,6 @@ object EventQueryHelper {
     )
     private val KEYWORD_FIELDS = setOf(
         "$EVENT_SOURCE_TAG.$REFERENCE_ID_TAG",
-        "$EVENT_SOURCE_TAG.$FEATURE_TAG",
         "$EVENT_SOURCE_TAG.$SEVERITY_TAG",
         // Text fields with keyword
         "$EVENT_SOURCE_TAG.$TAGS_TAG.$KEYWORD_SUFFIX",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/SendTestNotificationRequest.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/SendTestNotificationRequest.kt
@@ -17,7 +17,6 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.notifications.NotificationConstants.CONFIG_ID_TAG
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_TAG
 import org.opensearch.commons.utils.logger
 import java.io.IOException
 
@@ -25,7 +24,6 @@ import java.io.IOException
  * Action Request to send test notification.
  */
 class SendTestNotificationRequest : ActionRequest, ToXContentObject {
-    val feature: String
     val configId: String
 
     companion object {
@@ -43,7 +41,6 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
         @JvmStatic
         @Throws(IOException::class)
         fun parse(parser: XContentParser): SendTestNotificationRequest {
-            var feature: String? = null
             var configId: String? = null
 
             XContentParserUtils.ensureExpectedToken(
@@ -55,7 +52,6 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    FEATURE_TAG -> feature = parser.text()
                     CONFIG_ID_TAG -> configId = parser.text()
                     else -> {
                         parser.skipChildren()
@@ -63,22 +59,18 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
                     }
                 }
             }
-            feature ?: throw IllegalArgumentException("$FEATURE_TAG field absent")
             configId ?: throw IllegalArgumentException("$CONFIG_ID_TAG field absent")
-            return SendTestNotificationRequest(feature, configId)
+            return SendTestNotificationRequest(configId)
         }
     }
 
     /**
      * constructor for creating the class
-     * @param feature the notification info
      * @param configId the id of the notification configuration channel
      */
     constructor(
-        feature: String,
         configId: String,
     ) {
-        this.feature = feature
         this.configId = configId
     }
 
@@ -87,7 +79,6 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
      */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
-        feature = input.readString()
         configId = input.readString()
     }
 
@@ -97,7 +88,6 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         super.writeTo(output)
-        output.writeString(feature)
         output.writeString(configId)
     }
 
@@ -107,7 +97,6 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
         builder!!
         return builder.startObject()
-            .field(FEATURE_TAG, feature)
             .field(CONFIG_ID_TAG, configId)
             .endObject()
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationConfigRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationConfigRestHandler.kt
@@ -108,7 +108,6 @@ internal class NotificationConfigRestHandler : PluginBaseHandler() {
              *     created_time_ms=from_time..to_time (Range filter field)
              *     is_enabled=true (Boolean filter field)
              *     config_type=slack,chime (Keyword filter field)
-             *     feature_list=alerting,reports (Keyword filter field)
              *     name=test (Text filter field)
              *     description=sample (Text filter field)
              *     email.email_account_id=abc,xyz (Keyword filter field)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationEventRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationEventRestHandler.kt
@@ -68,11 +68,10 @@ internal class NotificationEventRestHandler : PluginBaseHandler() {
              *     from_index=20
              *     max_items=10
              *     sort_order=asc
-             *     sort_field=event_source.feature
+             *     sort_field=event_source.severity
              *     last_updated_time_ms=from_time..to_time (Range filter field)
              *     created_time_ms=from_time..to_time (Range filter field)
              *     event_source.reference_id=abc,xyz (Keyword filter field)
-             *     event_source.feature=alerting,reports (Keyword filter field)
              *     event_source.severity=info,high (Keyword filter field)
              *     event_source.tags=test,tags (Text filter field)
              *     event_source.title=sample title (Text filter field)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationFeatureChannelListRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/NotificationFeatureChannelListRestHandler.kt
@@ -6,7 +6,6 @@
 package org.opensearch.notifications.resthandler
 
 import org.opensearch.client.node.NodeClient
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_TAG
 import org.opensearch.commons.notifications.NotificationsPluginInterface
 import org.opensearch.commons.notifications.action.GetFeatureChannelListRequest
 import org.opensearch.notifications.NotificationPlugin.Companion.PLUGIN_BASE_URI
@@ -20,7 +19,7 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestToXContentListener
 
 /**
- * Rest handler for getting notification channels for a feature.
+ * Rest handler for getting notification channels.
  */
 internal class NotificationFeatureChannelListRestHandler : PluginBaseHandler() {
     companion object {
@@ -44,11 +43,11 @@ internal class NotificationFeatureChannelListRestHandler : PluginBaseHandler() {
         return listOf(
             /**
              * Get a notification event
-             * Request URL: GET [REQUEST_URL/{feature}]
+             * Request URL: GET [REQUEST_URL]
              * Request body: Ref [org.opensearch.commons.notifications.action.GetFeatureChannelListRequest]
              * Response body: [org.opensearch.commons.notifications.action.GetFeatureChannelListResponse]
              */
-            Route(GET, "$REQUEST_URL/{$FEATURE_TAG}")
+            Route(GET, REQUEST_URL)
         )
     }
 
@@ -67,11 +66,10 @@ internal class NotificationFeatureChannelListRestHandler : PluginBaseHandler() {
             GET -> {
                 Metrics.NOTIFICATIONS_FEATURE_CHANNELS_INFO_TOTAL.counter.increment()
                 Metrics.NOTIFICATIONS_FEATURE_CHANNELS_INFO_INTERVAL_COUNT.counter.increment()
-                val feature = request.param(FEATURE_TAG)
                 RestChannelConsumer {
                     NotificationsPluginInterface.getFeatureChannelList(
                         client,
-                        GetFeatureChannelListRequest(feature),
+                        GetFeatureChannelListRequest(),
                         RestToXContentListener(it)
                     )
                 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
@@ -7,7 +7,6 @@ package org.opensearch.notifications.resthandler
 
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.notifications.NotificationConstants.CONFIG_ID_TAG
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_TAG
 import org.opensearch.notifications.NotificationPlugin.Companion.PLUGIN_BASE_URI
 import org.opensearch.notifications.action.SendTestNotificationAction
 import org.opensearch.notifications.metrics.Metrics
@@ -56,7 +55,7 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
      * {@inheritDoc}
      */
     override fun responseParams(): Set<String> {
-        return setOf(CONFIG_ID_TAG, FEATURE_TAG)
+        return setOf(CONFIG_ID_TAG)
     }
 
     /**
@@ -77,9 +76,8 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
     ) = RestChannelConsumer {
         Metrics.NOTIFICATIONS_SEND_TEST_MESSAGE_TOTAL.counter.increment()
         Metrics.NOTIFICATIONS_SEND_TEST_MESSAGE_INTERVAL_COUNT.counter.increment()
-        val feature = request.param(FEATURE_TAG)
         val configId = request.param(CONFIG_ID_TAG)
-        val sendTestNotificationRequest = SendTestNotificationRequest(feature, configId)
+        val sendTestNotificationRequest = SendTestNotificationRequest(configId)
         client.execute(
             SendTestNotificationAction.ACTION_TYPE,
             sendTestNotificationRequest,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccess.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccess.kt
@@ -26,10 +26,10 @@ interface UserAccess {
     /**
      * validate if user has access based on given access list
      */
-    fun doesUserHasAccess(user: User?, access: List<String>): Boolean
+    fun doesUserHaveAccess(user: User?, access: List<String>): Boolean
 
     /**
      * validate if user has send-notification access based on given access list
      */
-    fun doesUserHasSendAccess(user: User?, access: List<String>): Boolean
+    fun doesUserHaveSendAccess(user: User?, access: List<String>): Boolean
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccessManager.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccessManager.kt
@@ -49,7 +49,7 @@ internal object UserAccessManager : UserAccess {
     /**
      * {@inheritDoc}
      */
-    override fun doesUserHasAccess(user: User?, access: List<String>): Boolean {
+    override fun doesUserHaveAccess(user: User?, access: List<String>): Boolean {
         if (user == null || !PluginSettings.isRbacEnabled()) { // Filtering is disabled
             return true
         }
@@ -59,7 +59,7 @@ internal object UserAccessManager : UserAccess {
     /**
      * {@inheritDoc}
      */
-    override fun doesUserHasSendAccess(user: User?, access: List<String>): Boolean {
-        return !PluginSettings.filterSendByBackendRoles || doesUserHasAccess(user, access)
+    override fun doesUserHaveSendAccess(user: User?, access: List<String>): Boolean {
+        return !PluginSettings.filterSendByBackendRoles || doesUserHaveAccess(user, access)
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -212,7 +212,7 @@ object SendMessageActionHelper {
                 listOf(),
                 DeliveryStatus(RestStatus.NOT_FOUND.status.toString(), "Channel ${channelEntry.key} not found")
             )
-        } else if (!userAccess.doesUserHasSendAccess(user, channelEntry.value!!.configDoc.metadata.access)) {
+        } else if (!userAccess.doesUserHaveSendAccess(user, channelEntry.value!!.configDoc.metadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             return EventStatus(
                 channelEntry.key,
@@ -412,7 +412,7 @@ object SendMessageActionHelper {
                     "Sender ${email.emailAccountID} not found"
                 )
             )
-        } else if (!userAccess.doesUserHasSendAccess(user, accountDocInfo.configDoc.metadata.access)) {
+        } else if (!userAccess.doesUserHaveSendAccess(user, accountDocInfo.configDoc.metadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             return eventStatus.copy(
                 emailRecipientStatus = listOf(),
@@ -423,7 +423,7 @@ object SendMessageActionHelper {
             )
         }
         val accessDeniedGroupIds = childConfigMap.filterValues {
-            it != null && !userAccess.doesUserHasSendAccess(user, it.configDoc.metadata.access)
+            it != null && !userAccess.doesUserHaveSendAccess(user, it.configDoc.metadata.access)
         }.keys
         val invalidGroupIds = childConfigMap.filterValues { it == null }.keys
         val groups = childConfigMap.values.filterNotNull()

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendTestNotificationActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendTestNotificationActionHelper.kt
@@ -13,37 +13,36 @@ import org.opensearch.commons.notifications.model.SeverityType
  * Helper function for send transport action.
  */
 object SendTestNotificationActionHelper {
-    fun generateMessage(feature: String, configId: String): ChannelMessage {
+    fun generateMessage(configId: String): ChannelMessage {
         return ChannelMessage(
-            getMessageTextDescription(feature, configId),
-            getMessageHtmlDescription(feature, configId),
+            getMessageTextDescription(configId),
+            getMessageHtmlDescription(configId),
             null
         )
     }
 
-    fun generateEventSource(feature: String, configId: String): EventSource {
+    fun generateEventSource(configId: String): EventSource {
         return EventSource(
-            getMessageTitle(feature, configId),
+            getMessageTitle(configId),
             configId,
-            feature,
             SeverityType.INFO
         )
     }
 
-    private fun getMessageTitle(feature: String, configId: String): String {
-        return "[$feature] Test Message Title-$configId" // TODO: change as spec
+    private fun getMessageTitle(configId: String): String {
+        return "Test Message Title-$configId" // TODO: change as spec
     }
 
-    private fun getMessageTextDescription(feature: String, configId: String): String {
-        return "Test message content body for config id $configId\nfrom feature $feature" // TODO: change as spec
+    private fun getMessageTextDescription(configId: String): String {
+        return "Test message content body for config id $configId" // TODO: change as spec
     }
 
-    private fun getMessageHtmlDescription(feature: String, configId: String): String {
+    private fun getMessageHtmlDescription(configId: String): String {
         return """
             <html>
             <header><title>Test Message</title></header>
             <body>
-            <p>Test Message for config id $configId from feature $feature</p>
+            <p>Test Message for config id $configId</p>
             </body>
             </html>
         """.trimIndent() // TODO: change as spec

--- a/notifications/notifications/src/main/resources/notifications-config-mapping.yml
+++ b/notifications/notifications/src/main/resources/notifications-config-mapping.yml
@@ -34,8 +34,6 @@ properties:
             type: keyword
       config_type:
         type: keyword
-      feature_list:
-        type: keyword
       is_enabled:
         type: boolean
       slack: # slack configuration

--- a/notifications/notifications/src/main/resources/notifications-event-mapping.yml
+++ b/notifications/notifications/src/main/resources/notifications-event-mapping.yml
@@ -32,8 +32,6 @@ properties:
                 type: keyword
           reference_id:
             type: keyword
-          feature:
-            type: keyword
           severity:
             type: keyword
           tags:

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -5,9 +5,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.Chime
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
@@ -26,7 +23,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChime
         )
@@ -38,10 +34,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"${(referenceObject.configData as Chime).url}"}
             }
@@ -85,7 +77,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated config name",
             "this is a updated config description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             isEnabled = true,
             configData = updatedChime
         )
@@ -97,9 +88,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedObject.name}",
                 "description":"${updatedObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${updatedObject.features.elementAt(0)}"
-                ],
                 "is_enabled":${updatedObject.isEnabled},
                 "chime":{"url":"${(updatedObject.configData as Chime).url}"}
             }
@@ -153,7 +141,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChime
         )
@@ -165,10 +152,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "features":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "slack":{"url":"https://dummy.com"}
                 "chime":{"url":"${(referenceObject.configData as Chime).url}"}
@@ -190,7 +173,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChime
         )
@@ -202,10 +184,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"${(referenceObject.configData as Chime).url}"}
             }
@@ -228,9 +206,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a updated config name",
                 "description":"this is a updated config description",
                 "config_type":"slack",
-                "feature_list":[
-                    "$FEATURE_INDEX_MANAGEMENT"
-                ],
                 "is_enabled":"true",
                 "slack":{"url":"https://updated.domain.com/updated_slack_url#0987654321"}
             }
@@ -251,7 +226,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChimeConfigData
         )
@@ -263,9 +237,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}"                
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"http"}
             }
@@ -296,7 +267,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChime
         )
@@ -308,10 +278,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"${(referenceObject.configData as Chime).url}"}
             }
@@ -334,9 +300,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a updated config name",
                 "description":"this is a updated config description",
                 "config_type":"chime",
-                "feature_list":[
-                    "$FEATURE_INDEX_MANAGEMENT"
-                ],
                 "is_enabled":"true",
                 "chime":{"url":"https://updated.domain.com/updated_chime_url#0987654321"}
             }
@@ -355,9 +318,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a updated config name",
                 "description":"this is a updated config description",
                 "config_type":"chime",
-                "feature_list":[
-                    "$FEATURE_INDEX_MANAGEMENT"
-                ],
                 "is_enabled":"true",
                 "chime":{"url":"http"}
             }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/CreateNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/CreateNotificationConfigIT.kt
@@ -6,9 +6,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.Chime
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.MethodType
@@ -31,7 +28,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSlack
         )
@@ -43,10 +39,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"slack",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "slack":{"url":"${(referenceObject.configData as Slack).url}"}
             }
@@ -81,7 +73,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleChime
         )
@@ -94,10 +85,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"chime",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"${(referenceObject.configData as Chime).url}"}
             }
@@ -130,7 +117,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS, FEATURE_ALERTING),
             isEnabled = true,
             configData = sampleWebhook
         )
@@ -142,11 +128,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"webhook",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}",
-                    "${referenceObject.features.elementAt(2)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "webhook":{"url":"${(referenceObject.configData as Webhook).url}"}
             }
@@ -179,7 +160,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             "this is another config name",
             "this is another config description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = anotherWebhook
         )
@@ -192,10 +172,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
                 "name":"${anotherObject.name}",
                 "description":"${anotherObject.description}",
                 "config_type":"webhook",
-                "feature_list":[
-                    "${anotherObject.features.elementAt(0)}",
-                    "${anotherObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${anotherObject.isEnabled},
                 "webhook":{"url":"${(anotherObject.configData as Webhook).url}"}
             }
@@ -223,7 +199,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             "this is a sample smtp account config name",
             "this is a sample smtp account config description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSmtpAccount
         )
@@ -236,9 +211,6 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
                 "name":"${smtpAccountConfig.name}",
                 "description":"${smtpAccountConfig.description}",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "${smtpAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${smtpAccountConfig.isEnabled},
                 "smtp_account":{
                     "host":"${sampleSmtpAccount.host}",

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
@@ -29,10 +29,6 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
                 "name":"this is a sample config name $randomString",
                 "description":"this is a sample config description $randomString",
                 "config_type":"slack",
-                "feature_list":[
-                    "index_management",
-                    "reports"
-                ],
                 "is_enabled":true,
                 "slack":{"url":"https://domain.com/sample_slack_url#$randomString"}
             }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
@@ -6,8 +6,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.Email
 import org.opensearch.commons.notifications.model.EmailGroup
@@ -39,7 +37,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample smtp account config name",
             "this is a sample smtp account config description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSmtpAccount
         )
@@ -51,9 +48,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${smtpAccountConfig.name}",
                 "description":"${smtpAccountConfig.description}",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "${smtpAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${smtpAccountConfig.isEnabled},
                 "smtp_account":{
                     "host":"${sampleSmtpAccount.host}",
@@ -80,7 +74,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample email group config name",
             "this is a sample email group config description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmailGroup
         )
@@ -92,9 +85,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailGroupConfig.name}",
                 "description":"${emailGroupConfig.description}",
                 "config_type":"email_group",
-                "feature_list":[
-                    "${emailGroupConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailGroupConfig.isEnabled},
                 "email_group":{
                     "recipient_list":[
@@ -125,7 +115,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -137,9 +126,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "email":{
                     "email_account_id":"${sampleEmail.emailAccountID}",
@@ -221,7 +207,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated smtp account config name",
             "this is a updated smtp account config description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = updatedSmtpAccount
         )
@@ -233,9 +218,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedSmtpAccountConfig.name}",
                 "description":"${updatedSmtpAccountConfig.description}",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "${updatedSmtpAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${updatedSmtpAccountConfig.isEnabled},
                 "smtp_account":{
                     "host":"${updatedSmtpAccount.host}",
@@ -317,7 +299,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample ses account config name",
             "this is a sample ses account config description",
             ConfigType.SES_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSesAccount
         )
@@ -329,9 +310,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${sesAccountConfig.name}",
                 "description":"${sesAccountConfig.description}",
                 "config_type":"ses_account",
-                "feature_list":[
-                    "${sesAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${sesAccountConfig.isEnabled},
                 "ses_account":{
                     "region":"${sampleSesAccount.awsRegion}",
@@ -357,7 +335,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample email group config name",
             "this is a sample email group config description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmailGroup
         )
@@ -369,9 +346,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailGroupConfig.name}",
                 "description":"${emailGroupConfig.description}",
                 "config_type":"email_group",
-                "feature_list":[
-                    "${emailGroupConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailGroupConfig.isEnabled},
                 "email_group":{
                     "recipient_list":[
@@ -402,7 +376,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -414,9 +387,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "email":{
                     "email_account_id":"${sampleEmail.emailAccountID}",
@@ -497,7 +467,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated ses account config name",
             "this is a updated ses account config description",
             ConfigType.SES_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = updatedSesAccount
         )
@@ -509,9 +478,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedSesAccountConfig.name}",
                 "description":"${updatedSesAccountConfig.description}",
                 "config_type":"ses_account",
-                "feature_list":[
-                    "${updatedSesAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${updatedSesAccountConfig.isEnabled},
                 "ses_account":{
                     "region":"${updatedSesAccount.awsRegion}",
@@ -589,9 +555,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"sample smtp account config name",
                 "description":"sample smtp account config description",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "reports"
-                ],
                 "is_enabled":true,
                 "smtp_account":{
                     "host":"smtp.domain.com",
@@ -622,7 +585,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -634,9 +596,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "email":{
                     "email_account_id":"${sampleEmail.emailAccountID}",
@@ -680,7 +639,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -692,9 +650,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "email":{
                     "email_account_id":"${sampleEmail.emailAccountID}",
@@ -738,7 +693,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample smtp account config name",
             "this is a sample smtp account config description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSmtpAccount
         )
@@ -750,9 +704,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${smtpAccountConfig.name}",
                 "description":"${smtpAccountConfig.description}",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "${smtpAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${smtpAccountConfig.isEnabled},
                 "smtp_account":{
                     "host":"${sampleSmtpAccount.host}",
@@ -783,7 +734,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -795,9 +745,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "email":{
                     "email_account_id":"${sampleEmail.emailAccountID}",
@@ -831,95 +778,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
     }
 
-    fun `test Create email notification config using email account id with unavailable feature should fail`() {
-        // Create smtp account notification config with reporting and alerting feature
-        val createSmtpAccountRequestJsonString = """
-        {
-            "config":{
-                "name":"sample smtp account config name",
-                "description":"sample smtp account config description",
-                "config_type":"smtp_account",
-                "feature_list":[
-                    "reports",
-                    "alerting"
-                ],
-                "is_enabled":true,
-                "smtp_account":{
-                    "host":"smtp.domain.com",
-                    "port":"1234",
-                    "method":"start_tls",
-                    "from_address":"from@domain.com"
-                }
-            }
-        }
-        """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
-        Assert.assertNotNull(smtpAccountConfigId)
-        Thread.sleep(100)
-
-        // Create sample email config request reference with reports and index_management
-        val sampleEmail = Email(
-            smtpAccountConfigId,
-            listOf(EmailRecipient("default-email1@email.com"), EmailRecipient("default-email2@email.com")),
-            listOf()
-        )
-        val emailConfig = NotificationConfig(
-            "this is a sample config name",
-            "this is a sample config description",
-            ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS, FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmail
-        )
-
-        // Create email notification config
-        val createEmailRequestJsonString = """
-        {
-            "config":{
-                "name":"${emailConfig.name}",
-                "description":"${emailConfig.description}",
-                "config_type":"email",
-                "feature_list":[
-                    "${emailConfig.features.elementAt(0)}",
-                    "${emailConfig.features.elementAt(1)}"
-                ],
-                "is_enabled":${emailConfig.isEnabled},
-                "email":{
-                    "email_account_id":"${sampleEmail.emailAccountID}",
-                    "recipient_list":[
-                        {"recipient":"${sampleEmail.recipients[0].recipient}"},
-                        {"recipient":"${sampleEmail.recipients[1].recipient}"}
-                    ],
-                    "email_group_id_list":[]
-                }
-            }
-        }
-        """.trimIndent()
-        executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailRequestJsonString,
-            RestStatus.FORBIDDEN.status
-        )
-        Thread.sleep(1000)
-
-        // Get all notification config should give only email group
-        val getAllConfigResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
-            "",
-            RestStatus.OK.status
-        )
-        verifySingleConfigIdEquals(smtpAccountConfigId, getAllConfigResponse)
-        Thread.sleep(100)
-    }
-
     fun `test Create email notification config wit email_group IDs put as email account id should fail`() {
 
         // Create email group notification config
@@ -929,7 +787,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"sample email group name",
                 "description":"sample email group description",
                 "config_type":"email_group",
-                "feature_list":["reports"],
                 "is_enabled":true,
                 "email_group":{
                     "recipient_list":[ {"recipient":"email1@email.com"}, {"recipient":"email2@email.com"}]
@@ -954,7 +811,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"email",
-                "feature_list":["reports"],
                 "is_enabled":true,
                 "email":{
                     "email_account_id":"$emailGroupConfigId",
@@ -991,9 +847,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"sample smtp account config name",
                 "description":"sample smtp account config description",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "reports"
-                ],
                 "is_enabled":true,
                 "smtp_account":{
                     "host":"smtp.domain.com",
@@ -1019,7 +872,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"email",
-                "feature_list":["reports"],
                 "is_enabled":true,
                 "email":{
                     "email_account_id":"$smtpAccountConfigId",
@@ -1056,9 +908,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"sample smtp account config name",
                 "description":"sample smtp account config description",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "reports"
-                ],
                 "is_enabled":true,
                 "smtp_account":{
                     "host":"smtp.domain.com",
@@ -1095,7 +944,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"email",
-                "feature_list":["reports"],
                 "is_enabled":true,
                 "email":{
                     "email_account_id":"$smtpAccountConfigId",
@@ -1136,7 +984,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample smtp account config name",
             "this is a sample smtp account config description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSmtpAccount
         )
@@ -1148,9 +995,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${smtpAccountConfig.name}",
                 "description":"${smtpAccountConfig.description}",
                 "config_type":"smtp_account",
-                "features":[
-                    "${smtpAccountConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${smtpAccountConfig.isEnabled},
                 "slack": {"url": "https://dummy.com"},
                 "smtp_account":{
@@ -1181,7 +1025,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.EMAIL,
-            setOf(FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleEmail
         )
@@ -1193,9 +1036,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${emailConfig.name}",
                 "description":"${emailConfig.description}",
                 "config_type":"email",
-                "features":[
-                    "${emailConfig.features.elementAt(0)}"
-                ],
                 "is_enabled":${emailConfig.isEnabled},
                 "slack":{"url": "https://dummy.com"},
                 "email":{

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
@@ -6,8 +6,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.Slack
@@ -26,7 +24,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSlack
         )
@@ -38,10 +35,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"slack",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "slack":{"url":"${(referenceObject.configData as Slack).url}"}
             }
@@ -85,7 +78,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated config name",
             "this is a updated config description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = updatedSlack
         )
@@ -97,10 +89,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedObject.name}",
                 "description":"${updatedObject.description}",
                 "config_type":"slack",
-                "feature_list":[
-                    "${updatedObject.features.elementAt(0)}",
-                    "${updatedObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${updatedObject.isEnabled},
                 "slack":{"url":"${(updatedObject.configData as Slack).url}"}
             }
@@ -154,7 +142,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSlack
         )
@@ -166,10 +153,6 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"slack",
-                "features":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"https://dummy.com"}
                 "slack":{"url":"${(referenceObject.configData as Slack).url}"}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
@@ -6,8 +6,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.Sns
@@ -26,7 +24,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.SNS,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSns
         )
@@ -38,10 +35,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"sns",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "sns":{"topic_arn":"${(referenceObject.configData as Sns).topicArn}","role_arn":"${(referenceObject.configData as Sns).roleArn}"}
             }
@@ -85,7 +78,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated config name",
             "this is a updated config description",
             ConfigType.SNS,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = updatedSns
         )
@@ -97,10 +89,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedObject.name}",
                 "description":"${updatedObject.description}",
                 "config_type":"sns",
-                "feature_list":[
-                    "${updatedObject.features.elementAt(0)}",
-                    "${updatedObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${updatedObject.isEnabled},
                 "sns":{"topic_arn":"${(updatedObject.configData as Sns).topicArn}","role_arn":"${(updatedObject.configData as Sns).roleArn}"}
             }
@@ -154,7 +142,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.SNS,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = sampleSns
         )
@@ -166,10 +153,6 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"sns",
-                "features":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "chime":{"url":"https://dummy.com"}
                 "sns":{"topic_arn":"${(referenceObject.configData as Sns).topicArn}","role_arn":"${(referenceObject.configData as Sns).roleArn}"}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
@@ -6,9 +6,6 @@
 package org.opensearch.integtest.config
 
 import org.junit.Assert
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.Webhook
@@ -30,7 +27,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS, FEATURE_ALERTING),
             isEnabled = true,
             configData = sampleWebhook
         )
@@ -42,11 +38,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"webhook",
-                "feature_list":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}",
-                    "${referenceObject.features.elementAt(2)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "webhook":{
                     "url":"${(referenceObject.configData as Webhook).url}",
@@ -98,7 +89,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a updated config name",
             "this is a updated config description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS),
             isEnabled = true,
             configData = updatedWebhook
         )
@@ -110,10 +100,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${updatedObject.name}",
                 "description":"${updatedObject.description}",
                 "config_type":"webhook",
-                "feature_list":[
-                    "${updatedObject.features.elementAt(0)}",
-                    "${updatedObject.features.elementAt(1)}"
-                ],
                 "is_enabled":${updatedObject.isEnabled},
                 "webhook":{
                     "url":"${(updatedObject.configData as Webhook).url}",
@@ -172,7 +158,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
             "this is a sample config name",
             "this is a sample config description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, FEATURE_REPORTS, FEATURE_ALERTING),
             isEnabled = true,
             configData = sampleWebhook
         )
@@ -184,11 +169,6 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
                 "name":"${referenceObject.name}",
                 "description":"${referenceObject.description}",
                 "config_type":"webhook",
-                "features":[
-                    "${referenceObject.features.elementAt(0)}",
-                    "${referenceObject.features.elementAt(1)}",
-                    "${referenceObject.features.elementAt(2)}"
-                ],
                 "is_enabled":${referenceObject.isEnabled},
                 "slack":{"url":"https://dummy.com"}
                 "webhook":{"url":"${(referenceObject.configData as Webhook).url}"}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
@@ -24,11 +24,6 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"chime",
-                "feature_list":[
-                    "index_management",
-                    "reports",
-                    "alerting"
-                ],
                 "is_enabled":true,
                 "chime":{
                     "url":"https://hooks.chime.aws/incomingwebhooks/xxxx"
@@ -49,7 +44,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
         // send test message
         val sendResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/feature/test/$configId?feature=alerting",
+            "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
         )
@@ -83,11 +78,6 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"slack",
-                "feature_list":[
-                    "index_management",
-                    "reports",
-                    "alerting"
-                ],
                 "is_enabled":true,
                 "slack":{
                     "url":"https://hooks.slack.com/services/xxx/xxx"
@@ -108,7 +98,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
         // send test message
         val sendResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/feature/test/$configId?feature=alerting",
+            "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
         )
@@ -143,11 +133,6 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
                 "name":"this is a sample config name",
                 "description":"this is a sample config description",
                 "config_type":"webhook",
-                "feature_list":[
-                    "index_management",
-                    "reports",
-                    "alerting"
-                ],
                 "is_enabled":true,
                 "webhook":{
                     "url":"https://szhongna.api.stdlib.com/my-webhook@dev/",
@@ -171,7 +156,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
         // send test message
         val sendResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/feature/test/$configId?feature=alerting",
+            "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
         )
@@ -212,11 +197,6 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
                 "name":"this is a sample smtp",
                 "description":"this is a sample smtp description",
                 "config_type":"smtp_account",
-                "feature_list":[
-                    "index_management",
-                    "reports",
-                    "alerting"
-                ],
                 "is_enabled":true,
                 "smtp_account":{
                     "host":"${sampleSmtpAccount.host}",
@@ -243,11 +223,6 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
                 "name":"email config name",
                 "description":"email description",
                 "config_type":"email",
-                "feature_list":[
-                    "index_management",
-                    "reports",
-                    "alerting"
-                ],
                 "is_enabled":true,
                 "email":{
                     "email_account_id":"$smtpAccountConfigId",
@@ -273,7 +248,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
         // send test message
         val sendResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/feature/test/$emailConfigId?feature=alerting",
+            "$PLUGIN_BASE_URI/feature/test/$emailConfigId",
             "",
             RestStatus.SERVICE_UNAVAILABLE.status
         )

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/ObjectEqualsHelpers.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/ObjectEqualsHelpers.kt
@@ -80,9 +80,6 @@ fun verifyEquals(config: NotificationConfig, jsonObject: JsonObject) {
     Assert.assertEquals(config.description, jsonObject.get("description").asString)
     Assert.assertEquals(config.configType.tag, jsonObject.get("config_type").asString)
     Assert.assertEquals(config.isEnabled, jsonObject.get("is_enabled").asBoolean)
-    val features = jsonObject.get("feature_list").asJsonArray
-    Assert.assertEquals(config.features.size, features.size())
-    features.forEach { config.features.contains(it.asString) }
     when (config.configType) {
         ConfigType.SLACK -> verifyEquals((config.configData as Slack), jsonObject.get("slack").asJsonObject)
         ConfigType.CHIME -> verifyEquals((config.configData as Chime), jsonObject.get("chime").asJsonObject)

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/NotificationEventIndexTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/NotificationEventIndexTests.kt
@@ -26,7 +26,6 @@ import org.opensearch.cluster.routing.RoutingTable
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.DeliveryStatus
 import org.opensearch.commons.notifications.model.EventSource
@@ -65,7 +64,6 @@ internal class NotificationEventIndexTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             tags = listOf("tag1", "tag2"),
             severity = SeverityType.INFO
         )

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/NotificationConfigDocTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/NotificationConfigDocTests.kt
@@ -7,7 +7,6 @@ package org.opensearch.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.Slack
@@ -31,7 +30,6 @@ internal class NotificationConfigDocTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configDoc = NotificationConfigDoc(metadata, config)
@@ -54,7 +52,6 @@ internal class NotificationConfigDocTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configDoc = NotificationConfigDoc(metadata, config)
@@ -69,7 +66,6 @@ internal class NotificationConfigDocTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"slack",
-                "feature_list":["reports"],
                 "is_enabled":true,
                 "slack":{"url":"https://domain.com/sample_url#1234567890"}
             },
@@ -90,7 +86,6 @@ internal class NotificationConfigDocTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"slack",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "slack":{"url":"https://domain.com/sample_slack_url#1234567890"}
             }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/NotificationEventDocTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/NotificationEventDocTests.kt
@@ -7,7 +7,6 @@ package org.opensearch.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.DeliveryStatus
 import org.opensearch.commons.notifications.model.EventSource
@@ -32,7 +31,6 @@ internal class NotificationEventDocTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             tags = listOf("tag1", "tag2"),
             severity = SeverityType.INFO
         )
@@ -61,7 +59,6 @@ internal class NotificationEventDocTests {
         val eventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             tags = listOf("tag1", "tag2"),
             severity = SeverityType.INFO
         )
@@ -84,7 +81,6 @@ internal class NotificationEventDocTests {
                 "event_source":{
                     "title":"title",
                     "reference_id":"reference_id",
-                    "feature":"alerting",
                     "severity":"info",
                     "tags":["tag1", "tag2"]
                 },
@@ -118,7 +114,6 @@ internal class NotificationEventDocTests {
                 "event_source":{
                     "title":"title",
                     "reference_id":"reference_id",
-                    "feature":"alerting",
                     "severity":"info",
                     "tags":["tag1", "tag2"]
                 },

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/SendTestNotificationRequestTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/SendTestNotificationRequestTests.kt
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.core.JsonParseException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.notifications.createObjectFromJsonString
 import org.opensearch.notifications.getJsonString
@@ -23,20 +20,19 @@ internal class SendTestNotificationRequestTests {
         expected: SendTestNotificationRequest,
         actual: SendTestNotificationRequest
     ) {
-        assertEquals(expected.feature, actual.feature)
         assertEquals(expected.configId, actual.configId)
     }
 
     @Test
     fun `Send test request serialize and deserialize transport object should be equal`() {
-        val sendTestRequest = SendTestNotificationRequest(FEATURE_REPORTS, "configId")
+        val sendTestRequest = SendTestNotificationRequest("configId")
         val recreatedObject = recreateObject(sendTestRequest) { SendTestNotificationRequest(it) }
         assertSendTestRequestEquals(sendTestRequest, recreatedObject)
     }
 
     @Test
     fun `Send test request serialize and deserialize using json object should be equal`() {
-        val sendTestRequest = SendTestNotificationRequest(FEATURE_INDEX_MANAGEMENT, "configId")
+        val sendTestRequest = SendTestNotificationRequest("configId")
         val jsonString = getJsonString(sendTestRequest)
         val recreatedObject = createObjectFromJsonString(jsonString) { SendTestNotificationRequest.parse(it) }
         assertSendTestRequestEquals(sendTestRequest, recreatedObject)
@@ -52,22 +48,21 @@ internal class SendTestNotificationRequestTests {
 
     @Test
     fun `Send test request should return null for valid request`() {
-        val sendTestRequest = SendTestNotificationRequest(FEATURE_INDEX_MANAGEMENT, "configId")
+        val sendTestRequest = SendTestNotificationRequest("configId")
         assertNull(sendTestRequest.validate())
     }
 
     @Test
     fun `Send test request should return exception when configId is empty for validate`() {
-        val sendTestRequest = SendTestNotificationRequest(FEATURE_INDEX_MANAGEMENT, "")
+        val sendTestRequest = SendTestNotificationRequest("")
         assertNotNull(sendTestRequest.validate())
     }
 
     @Test
     fun `Send test request should safely ignore extra field in json object`() {
-        val sendTestRequest = SendTestNotificationRequest(FEATURE_ALERTING, "configId")
+        val sendTestRequest = SendTestNotificationRequest("configId")
         val jsonString = """
         {
-            "feature":"${sendTestRequest.feature}",
             "config_id":"${sendTestRequest.configId}",
             "extra_field_1":["extra", "value"],
             "extra_field_2":{"extra":"value"},
@@ -79,22 +74,10 @@ internal class SendTestNotificationRequestTests {
     }
 
     @Test
-    fun `Send test request should throw exception if feature field is absent in json object`() {
-        val jsonString = """
-        {
-            "config_id":"configId"
-        }
-        """.trimIndent()
-        assertThrows<IllegalArgumentException> {
-            createObjectFromJsonString(jsonString) { SendTestNotificationRequest.parse(it) }
-        }
-    }
-
-    @Test
     fun `Send test request should throw exception if configId field is absent in json object`() {
         val jsonString = """
         {
-            "feature":"feature"
+            "extra_field_1":"extra value 1"
         }
         """.trimIndent()
         assertThrows<IllegalArgumentException> {


### PR DESCRIPTION
### Description
* Updates Kotlin to 1.6.10 (this was to be consistent with common-utils and caused compilation errors which were also fixed in this PR)
* Removes feature and feature_list usage in backend and frontend

This PR is making changes to integrate the changes in https://github.com/opensearch-project/common-utils/pull/136

**Note**: During manual testing on the frontend it became apparent that the frontend is incorrectly forming an Email channel object (the recipient is a list of Strings instead of list of EmailRecipient objects i.e `{ "recipient": "email@test.com" }` like the backend expects). We may favor the frontend format here since wrapping it in an object seems unnecessary. In either case, this will be addressed in a follow-up PR.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
