### PR TITLE
Fix recipient_list format for Email Channel in frontend to match backend

### DIFF
--- a/dashboards-notifications/models/interfaces.ts
+++ b/dashboards-notifications/models/interfaces.ts
@@ -44,7 +44,7 @@ export interface ChannelItemType extends ConfigType {
   };
   email?: {
     email_account_id: string;
-    recipient_list: string[]; // custom email addresses
+    recipient_list: { [recipient: string]: string }[]; // custom email addresses
     email_group_id_list: string[];
     // optional fields for displaying or editing email channel, needs more requests
     sender_type?: SenderType;

--- a/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
+++ b/dashboards-notifications/public/pages/CreateChannel/__tests__/helper.test.ts
@@ -154,7 +154,10 @@ describe('constructs and deconstructs email objects', () => {
       'recipient-group-id-2',
       'recipient-group-id-3',
     ],
-    recipient_list: ['custom.address1@email.com', 'custom.address2@email.com'],
+    recipient_list: [
+      { recipient: 'custom.address1@email.com' },
+      { recipient: 'custom.address2@email.com' },
+    ],
   };
 
   it('constructs email objects', () => {

--- a/dashboards-notifications/public/pages/CreateChannel/utils/helper.ts
+++ b/dashboards-notifications/public/pages/CreateChannel/utils/helper.ts
@@ -112,7 +112,7 @@ export const constructEmailObject = (
     if (group.value) {
       recipientGroupIds.push(group.value);
     } else {
-      customEmailsList.push(group.label);
+      customEmailsList.push({ recipient: group.label });
     }
   }
   return {
@@ -142,7 +142,7 @@ export const deconstructEmailObject = (
       label: _.get(email.email_group_id_map, groupId, '-'),
       value: groupId,
     })),
-    ...email.recipient_list.map((address) => ({ label: address })),
+    ...email.recipient_list.map((recipient) => ({ label: recipient.recipient })),
   ];
   return {
     senderType: email.sender_type!,

--- a/dashboards-notifications/test/mocks/mockData.ts
+++ b/dashboards-notifications/test/mocks/mockData.ts
@@ -43,7 +43,11 @@ const mockEmail: ChannelItemType = {
   is_enabled: true,
   email: {
     email_account_id: 'dj8etXkBCzVy9Vy-nsiL',
-    recipient_list: ['custom@email.com', 'email@test.com', 'test@email.com'],
+    recipient_list: [
+      { recipient: 'custom@email.com' },
+      { recipient: 'email@test.com' },
+      { recipient: 'test@email.com' },
+    ],
     email_group_id_list: [
       '1l8hq3kB0XwiBlEbanSo',
       'dz8etXkBCzVy9Vy-0sgh',
@@ -76,7 +80,11 @@ const mockEmailWithSES: ChannelItemType = {
   is_enabled: true,
   email: {
     email_account_id: 'dj8etXkBCzVy9Vy-nsiL',
-    recipient_list: ['custom@email.com', 'email@test.com', 'test@email.com'],
+    recipient_list: [
+      { recipient: 'custom@email.com' },
+      { recipient: 'email@test.com' },
+      { recipient: 'test@email.com' },
+    ],
     email_group_id_list: [
       '1y8ud3xO0KjvOyRonaFb',
       'qm8rgKxOPmIl9Il-0ftu',


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
The Email channel format for the backend API expects a format like the following:
```
  "email": {
    "email_account_id": "ZbnVdX8BBb20pFuVr_za",
    "recipient_list": [
      {
        "recipient": "test-email1@email.com“ 
      },
      {
        "recipient": "test-email2@email.com“
      }
    ],
    "email_group_id_list": [
      "ZLnJdX8BBb20pFuV8Pwl"
    ]
  }
```
 
This `recipient_list` format is also used for defining emails in the Email Group configs. However, the frontend was providing recipient_list to the backend in this format when creating Email channels causing the request to fail:
```
"recipient_list": [
  "test-email1@email.com“ 
  "test-email2@email.com“
],
```

This PR updates the formatting from the frontend so the request is valid. Changing the backend formatting of `recipient_list` to not have the recipient emails wrapped in an object was considered but that change was more intrusive and didn't add any real functional benefit.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
