### PR TITLE
Remove usage of allowedConfigFeatures

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationCore.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/NotificationCore.kt
@@ -20,11 +20,6 @@ interface NotificationCore {
     fun getAllowedConfigTypes(): List<String>
 
     /**
-     * Get list of allowed config features
-     */
-    fun getAllowedConfigFeatures(): List<String>
-
-    /**
      * Get map of plugin features
      */
     fun getPluginFeatures(): Map<String, String>

--- a/notifications/core/src/main/config/notifications-core.yml
+++ b/notifications/core/src/main/config/notifications-core.yml
@@ -16,5 +16,4 @@ opensearch.notifications.core:
     socketTimeout: 50000
     hostDenyList: []
   allowedConfigTypes: ["slack","chime","webhook","email","sns","ses_account","smtp_account","email_group"]
-  allowedConfigFeatures: ["alerting", "index_management", "reports"]
   tooltipSupport: true

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCoreImpl.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCoreImpl.kt
@@ -52,17 +52,6 @@ object NotificationCoreImpl : NotificationCore {
     }
 
     /**
-     * Get list of allowed config features
-     */
-    override fun getAllowedConfigFeatures(): List<String> {
-        return AccessController.doPrivileged(
-            PrivilegedAction {
-                PluginSettings.allowedConfigFeatures
-            } as PrivilegedAction<List<String>>?
-        )
-    }
-
-    /**
      * Get map of plugin features
      */
     override fun getPluginFeatures(): Map<String, String> {

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
@@ -83,11 +83,6 @@ internal object PluginSettings {
     private const val ALLOWED_CONFIG_TYPE_KEY = "$KEY_PREFIX.allowedConfigTypes"
 
     /**
-     * Setting to choose allowed config features.
-     */
-    private const val ALLOWED_CONFIG_FEATURE_KEY = "$KEY_PREFIX.allowedConfigFeatures"
-
-    /**
      * Setting to enable tooltip in UI
      */
     private const val TOOLTIP_SUPPORT_KEY = "$KEY_PREFIX.tooltipSupport"
@@ -142,15 +137,6 @@ internal object PluginSettings {
     )
 
     /**
-     * Default config feature list
-     */
-    private val DEFAULT_ALLOWED_CONFIG_FEATURES = listOf(
-        "alerting",
-        "index_management",
-        "reports"
-    )
-
-    /**
      * Default email host deny list
      */
     private val DEFAULT_HOST_DENY_LIST = emptyList<String>()
@@ -170,12 +156,6 @@ internal object PluginSettings {
      */
     @Volatile
     var allowedConfigTypes: List<String>
-
-    /**
-     * list of allowed config features.
-     */
-    @Volatile
-    var allowedConfigFeatures: List<String>
 
     /**
      * Email size limit setting
@@ -258,7 +238,6 @@ internal object PluginSettings {
             ?: DEFAULT_CONNECTION_TIMEOUT_MILLISECONDS
         socketTimeout = (settings?.get(SOCKET_TIMEOUT_MILLISECONDS_KEY)?.toInt()) ?: DEFAULT_SOCKET_TIMEOUT_MILLISECONDS
         allowedConfigTypes = settings?.getAsList(ALLOWED_CONFIG_TYPE_KEY, null) ?: DEFAULT_ALLOWED_CONFIG_TYPES
-        allowedConfigFeatures = settings?.getAsList(ALLOWED_CONFIG_FEATURE_KEY, null) ?: DEFAULT_ALLOWED_CONFIG_FEATURES
         tooltipSupport = settings?.getAsBoolean(TOOLTIP_SUPPORT_KEY, true) ?: DEFAULT_TOOLTIP_SUPPORT
         hostDenyList = settings?.getAsList(HOST_DENY_LIST_KEY, null) ?: DEFAULT_HOST_DENY_LIST
         destinationSettings = if (settings != null) loadDestinationSettings(settings) else DEFAULT_DESTINATION_SETTINGS
@@ -318,13 +297,6 @@ internal object PluginSettings {
         NodeScope, Dynamic
     )
 
-    val ALLOWED_CONFIG_FEATURES: Setting<List<String>> = Setting.listSetting(
-        ALLOWED_CONFIG_FEATURE_KEY,
-        DEFAULT_ALLOWED_CONFIG_FEATURES,
-        { it },
-        NodeScope, Dynamic
-    )
-
     val TOOLTIP_SUPPORT: Setting<Boolean> = Setting.boolSetting(
         TOOLTIP_SUPPORT_KEY,
         defaultSettings[TOOLTIP_SUPPORT_KEY]!!.toBoolean(),
@@ -364,7 +336,6 @@ internal object PluginSettings {
             CONNECTION_TIMEOUT_MILLISECONDS,
             SOCKET_TIMEOUT_MILLISECONDS,
             ALLOWED_CONFIG_TYPES,
-            ALLOWED_CONFIG_FEATURES,
             TOOLTIP_SUPPORT,
             HOST_DENY_LIST,
             EMAIL_USERNAME,
@@ -377,7 +348,6 @@ internal object PluginSettings {
      */
     private fun updateSettingValuesFromLocal(clusterService: ClusterService) {
         allowedConfigTypes = ALLOWED_CONFIG_TYPES.get(clusterService.settings)
-        allowedConfigFeatures = ALLOWED_CONFIG_FEATURES.get(clusterService.settings)
         emailSizeLimit = EMAIL_SIZE_LIMIT.get(clusterService.settings)
         emailMinimumHeaderLength = EMAIL_MINIMUM_HEADER_LENGTH.get(clusterService.settings)
         maxConnections = MAX_CONNECTIONS.get(clusterService.settings)
@@ -430,11 +400,6 @@ internal object PluginSettings {
             log.debug("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -autoUpdatedTo-> $clusterAllowedConfigTypes")
             allowedConfigTypes = clusterAllowedConfigTypes
         }
-        val clusterAllowedConfigFeatures = clusterService.clusterSettings.get(ALLOWED_CONFIG_FEATURES)
-        if (clusterAllowedConfigFeatures != null) {
-            log.debug("$LOG_PREFIX:$ALLOWED_CONFIG_FEATURE_KEY -autoUpdatedTo-> $clusterAllowedConfigFeatures")
-            allowedConfigFeatures = clusterAllowedConfigFeatures
-        }
         val clusterTooltipSupport = clusterService.clusterSettings.get(TOOLTIP_SUPPORT)
         if (clusterTooltipSupport != null) {
             log.debug("$LOG_PREFIX:$TOOLTIP_SUPPORT_KEY -autoUpdatedTo-> $clusterTooltipSupport")
@@ -460,10 +425,6 @@ internal object PluginSettings {
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOWED_CONFIG_TYPES) {
             allowedConfigTypes = it
             log.info("$LOG_PREFIX:$ALLOWED_CONFIG_TYPE_KEY -updatedTo-> $it")
-        }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOWED_CONFIG_FEATURES) {
-            allowedConfigFeatures = it
-            log.info("$LOG_PREFIX:$ALLOWED_CONFIG_FEATURE_KEY -updatedTo-> $it")
         }
         clusterService.clusterSettings.addSettingsUpdateConsumer(EMAIL_SIZE_LIMIT) {
             emailSizeLimit = it
@@ -542,7 +503,6 @@ internal object PluginSettings {
         connectionTimeout = DEFAULT_CONNECTION_TIMEOUT_MILLISECONDS
         socketTimeout = DEFAULT_SOCKET_TIMEOUT_MILLISECONDS
         allowedConfigTypes = DEFAULT_ALLOWED_CONFIG_TYPES
-        allowedConfigFeatures = DEFAULT_ALLOWED_CONFIG_FEATURES
         tooltipSupport = DEFAULT_TOOLTIP_SUPPORT
         hostDenyList = DEFAULT_HOST_DENY_LIST
     }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/NotificationCoreImplTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/NotificationCoreImplTests.kt
@@ -34,7 +34,6 @@ class NotificationCoreImplTests {
     @Test
     fun `test all get configs APIs return the default value`() {
         assertEquals(defaultConfigTypes, NotificationCoreImpl.getAllowedConfigTypes())
-        assertEquals(defaultConfigFeatures, NotificationCoreImpl.getAllowedConfigFeatures())
         assertEquals(defaultPluginFeatures, NotificationCoreImpl.getPluginFeatures())
     }
 }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
@@ -33,7 +33,6 @@ internal class PluginSettingsTests {
     private val httpSocketTimeoutKey = "$httpKeyPrefix.socketTimeout"
     private val httpHostDenyListKey = "$httpKeyPrefix.hostDenyList"
     private val allowedConfigTypeKey = "$keyPrefix.allowedConfigTypes"
-    private val allowedConfigFeatureKey = "$keyPrefix.allowedConfigFeatures"
     private val tooltipSupportKey = "$keyPrefix.tooltipSupport"
 
     private val defaultSettings = Settings.builder()
@@ -55,14 +54,6 @@ internal class PluginSettingsTests {
                 "ses_account",
                 "smtp_account",
                 "email_group"
-            )
-        )
-        .putList(
-            allowedConfigFeatureKey,
-            listOf(
-                "alerting",
-                "index_management",
-                "reports"
             )
         )
         .put(tooltipSupportKey, true)
@@ -93,7 +84,6 @@ internal class PluginSettingsTests {
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
-                    PluginSettings.ALLOWED_CONFIG_FEATURES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST
                 )
@@ -125,10 +115,6 @@ internal class PluginSettingsTests {
             PluginSettings.allowedConfigTypes.toString()
         )
         Assertions.assertEquals(
-            defaultSettings[allowedConfigFeatureKey],
-            PluginSettings.allowedConfigFeatures.toString()
-        )
-        Assertions.assertEquals(
             defaultSettings[tooltipSupportKey],
             PluginSettings.tooltipSupport.toString()
         )
@@ -149,7 +135,6 @@ internal class PluginSettingsTests {
             .put(httpSocketTimeoutKey, 100)
             .putList(httpHostDenyListKey, listOf("sample"))
             .putList(allowedConfigTypeKey, listOf("slack"))
-            .putList(allowedConfigFeatureKey, listOf("alerting"))
             .put(tooltipSupportKey, false)
             .build()
 
@@ -165,7 +150,6 @@ internal class PluginSettingsTests {
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
-                    PluginSettings.ALLOWED_CONFIG_FEATURES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST
                 )
@@ -201,10 +185,6 @@ internal class PluginSettingsTests {
             clusterService.clusterSettings.get(PluginSettings.ALLOWED_CONFIG_TYPES)
         )
         Assertions.assertEquals(
-            listOf("alerting"),
-            clusterService.clusterSettings.get(PluginSettings.ALLOWED_CONFIG_FEATURES)
-        )
-        Assertions.assertEquals(
             false,
             clusterService.clusterSettings.get(PluginSettings.TOOLTIP_SUPPORT)
         )
@@ -225,7 +205,6 @@ internal class PluginSettingsTests {
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
-                    PluginSettings.ALLOWED_CONFIG_FEATURES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST
                 )
@@ -259,10 +238,6 @@ internal class PluginSettingsTests {
         Assertions.assertEquals(
             defaultSettings[allowedConfigTypeKey],
             clusterService.clusterSettings.get(PluginSettings.ALLOWED_CONFIG_TYPES).toString()
-        )
-        Assertions.assertEquals(
-            defaultSettings[allowedConfigFeatureKey],
-            clusterService.clusterSettings.get(PluginSettings.ALLOWED_CONFIG_FEATURES).toString()
         )
         Assertions.assertEquals(
             defaultSettings[tooltipSupportKey],

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
@@ -58,12 +58,7 @@ internal class GetPluginFeaturesAction @Inject constructor(
         user: User?
     ): GetPluginFeaturesResponse {
         val allowedConfigTypes = CoreProvider.core.getAllowedConfigTypes()
-        val allowedConfigFeatures = CoreProvider.core.getAllowedConfigFeatures()
         val pluginFeatures = CoreProvider.core.getPluginFeatures()
-        return GetPluginFeaturesResponse(
-            allowedConfigTypes,
-            allowedConfigFeatures,
-            pluginFeatures
-        )
+        return GetPluginFeaturesResponse(allowedConfigTypes, pluginFeatures)
     }
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/features/GetPluginFeaturesIT.kt
@@ -22,7 +22,6 @@ class GetPluginFeaturesIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         Assert.assertFalse(getResponse.get("allowed_config_type_list").asJsonArray.isEmpty)
-        Assert.assertFalse(getResponse.get("allowed_config_feature_list").asJsonArray.isEmpty)
         val pluginFeatures = getResponse.get("plugin_features").asJsonObject
         Assert.assertFalse(pluginFeatures.keySet().isEmpty())
     }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -151,10 +151,9 @@ internal class PluginActionTests {
     @Test
     fun `Get plugin features action should call back action listener`() {
         val allowedConfigTypes = listOf("type1")
-        val allowedConfigFeatures = listOf("feature1")
         val pluginFeatures = mapOf(Pair("FeatureKey1", "Feature1"))
         val request = mock(GetPluginFeaturesRequest::class.java)
-        val response = GetPluginFeaturesResponse(allowedConfigTypes, allowedConfigFeatures, pluginFeatures)
+        val response = GetPluginFeaturesResponse(allowedConfigTypes, pluginFeatures)
 
         val getPluginFeaturesAction = GetPluginFeaturesAction(
             transportService, client, actionFilters, xContentRegistry


### PR DESCRIPTION
### Description
Related common-utils PR: https://github.com/opensearch-project/common-utils/pull/144

* Removes allowedConfigFeatures from the GetPluginFeaturesResponse to reflect the common-utils changes
* Removes allowedConfigFeatures from NotificationCore core interface in spi
* Removes the allowedConfigFeatures plugin setting
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
