### PR TITLE
Add support for -Dbuild.version_qualifier and remove usage of mapping types

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
-        opensearch_build = opensearch_version.replaceAll(/((?:\d\.)+\d)(.*)$/, '$1.0$2')
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)(-.*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
         junit_version = System.getProperty("junit.version", "5.7.2")

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,9 +6,9 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
-        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        opensearch_build = opensearch_version.replaceAll(/((?:\d\.)+\d)(.*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
         junit_version = System.getProperty("junit.version", "5.7.2")
@@ -38,11 +38,15 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")    
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+    buildVersionQualifier = System.getProperty("build.version_qualifier")
 }
 
 allprojects {
-    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    version = opensearch_version.tokenize('-')[0] + '.0'
+    if (buildVersionQualifier) {
+        version += "-${buildVersionQualifier}"
+    }
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationEventIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationEventIndex.kt
@@ -21,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.notifications.action.GetNotificationEventRequest
 import org.opensearch.commons.notifications.model.NotificationEventInfo
@@ -51,7 +52,6 @@ internal object NotificationEventIndex : EventOperations {
     private const val INDEX_NAME = ".opensearch-notifications-event"
     private const val MAPPING_FILE_NAME = "notifications-event-mapping.yml"
     private const val SETTINGS_FILE_NAME = "notifications-event-settings.yml"
-    private const val MAPPING_TYPE = "_doc"
 
     private lateinit var client: Client
     private lateinit var clusterService: ClusterService
@@ -90,9 +90,10 @@ internal object NotificationEventIndex : EventOperations {
         if (!isIndexExists()) {
             val classLoader = NotificationEventIndex::class.java.classLoader
             val indexMappingSource = classLoader.getResource(MAPPING_FILE_NAME)?.readText()!!
+            val indexMappingAsMap = XContentHelper.convertToMap(XContentType.YAML.xContent(), indexMappingSource, false)
             val indexSettingsSource = classLoader.getResource(SETTINGS_FILE_NAME)?.readText()!!
             val request = CreateIndexRequest(INDEX_NAME)
-                .mapping(MAPPING_TYPE, indexMappingSource, XContentType.YAML)
+                .mapping(indexMappingAsMap)
                 .settings(indexSettingsSource, XContentType.YAML)
             try {
                 val actionFuture = client.admin().indices().create(request)


### PR DESCRIPTION
### Description
* Adds support for `-Dbuild.version_qualifier` in `build.gradle`
* Changes OpenSearch version being used from `2.0.0` to `2.0.0-alpha1`
* Removes usage of mapping types
 
### Issues Resolved
#379 #375 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
