### PR TITLE
Add commons-logging as a runtime dependency

### DIFF
--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -67,7 +67,7 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-        force "commons-logging:commons-logging:1.2" // resolve for amazonaws
+        force "commons-logging:commons-logging:${versions.commonslogging}" // resolve for amazonaws
         force "commons-codec:commons-codec:1.13" // resolve for amazonaws
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
         force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -77,7 +77,7 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-        force "commons-logging:commons-logging:1.2" // resolve for amazonaws
+        force "commons-logging:commons-logging:${versions.commonslogging}" // resolve for amazonaws
         force "commons-codec:commons-codec:1.13" // resolve for amazonaws
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
         force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
@@ -96,6 +96,7 @@ compileKotlin { kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict'] }
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
+    implementation "commons-logging:commons-logging:${versions.commonslogging}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.apache.httpcomponents:httpcore:4.4.5"


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
When invoking the passthrough API from a consuming plugin of Notifications, the code hit a path that required the apache commons logging dependency at runtime. Since the dependency was not available on the runtime classpath, it would throw the following error and crash the cluster:
```
java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
	at org.apache.http.conn.ssl.AbstractVerifier.<init>(AbstractVerifier.java:61)
	at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<init>(AllowAllHostnameVerifier.java:44)
	at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<clinit>(AllowAllHostnameVerifier.java:46)
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.<clinit>(SSLConnectionSocketFactory.java:151)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.getDefaultRegistry(PoolingHttpClientConnectionManager.java:115)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.<init>(PoolingHttpClientConnectionManager.java:122)
	at org.opensearch.notifications.core.client.DestinationHttpClient$Companion.createHttpClient(DestinationHttpClient.kt:78)
	at org.opensearch.notifications.core.client.DestinationHttpClient$Companion.access$createHttpClient(DestinationHttpClient.kt:56)
	at org.opensearch.notifications.core.client.DestinationHttpClient.<init>(DestinationHttpClient.kt:49)
	at org.opensearch.notifications.core.client.DestinationClientPool.<clinit>(DestinationClientPool.kt:15)
	at org.opensearch.notifications.core.transport.WebhookDestinationTransport.<init>(WebhookDestinationTransport.kt:27)
	at org.opensearch.notifications.core.transport.DestinationTransportProvider.<clinit>(DestinationTransportProvider.kt:18)
	at org.opensearch.notifications.core.NotificationCoreImpl.sendMessage$lambda-0(NotificationCoreImpl.kt:37)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at org.opensearch.notifications.core.NotificationCoreImpl.sendMessage(NotificationCoreImpl.kt:35)
	at org.opensearch.notifications.send.SendMessageActionHelper.sendMessageThroughSpi(SendMessageActionHelper.kt:552)
	at org.opensearch.notifications.send.SendMessageActionHelper.sendMessageToLegacyDestination(SendMessageActionHelper.kt:298)
	at org.opensearch.notifications.send.SendMessageActionHelper.access$sendMessageToLegacyDestination(SendMessageActionHelper.kt:64)
	at org.opensearch.notifications.send.SendMessageActionHelper$executeLegacyRequest$1.invokeSuspend(SendMessageActionHelper.kt:132)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at org.opensearch.notifications.send.SendMessageActionHelper.executeLegacyRequest(SendMessageActionHelper.kt:131)
	at org.opensearch.notifications.action.PublishNotificationAction.executeRequest(PublishNotificationAction.kt:64)
	at org.opensearch.notifications.action.PublishNotificationAction.executeRequest(PublishNotificationAction.kt:30)
	at org.opensearch.notifications.action.PluginBaseAction$doExecute$1.invokeSuspend(PluginBaseAction.kt:63)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.logging.LogFactory
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
	at java.base/java.net.FactoryURLClassLoader.loadClass(URLClassLoader.java:872)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 37 more
```

This PR adds the `commons-logging` dependency to the runtime classpath for Notifications core (it was already there for the testing classpaths which is why `implementation` is used instead of `runtimeOnly`). When manually testing with plugins like Alerting and ISM, this resolved the issue when the passthrough API was called.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
