### PR TITLE
Fix backend build script

### DIFF
--- a/notifications/scripts/build.sh
+++ b/notifications/scripts/build.sh
@@ -70,19 +70,17 @@ fi
 mkdir -p $OUTPUT/maven
 mkdir -p $OUTPUT/plugins
 
-cd notifications
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
-cd ..
 
 mkdir -p $OUTPUT/plugins
 
-notifCoreZipPath=$(find . -path \*core/build/distributions/*.zip)
+notifCoreZipPath=$(find . -path \*core/build/distributions/\*.zip)
 distributions="$(dirname "${notifCoreZipPath}")"
 echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
-notifZipPath=$(find . -path \*notifications/build/distributions/*.zip)
+notifZipPath=$(find . -path \*notifications/build/distributions/\*.zip)
 distributions="$(dirname "${notifZipPath}")"
 echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
The working directory will be set to `notifications` in the build manifest so the `build.sh` script does not need to change directories before assembling.

Also, after testing the build locally it seems that the `find` command that was present in the script currently was not finding the zip file, updating it to a command that worked.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
