### PR TITLE
Added distribution build.sh.

### DIFF
--- a/notifications/scripts/build.sh
+++ b/notifications/scripts/build.sh
@@ -13,7 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
-    echo -e "-q QUALIFIER\t[Optional] Build qualifier."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -75,14 +75,8 @@ cd notifications
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 cd ..
 
+zipPath=$(find . -path \*/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
-
-notifCoreZipPath=$(find . -path \*core/build/distributions/*.zip)
-distributions="$(dirname "${notifCoreZipPath}")"
-echo "COPY ${distributions}/*.zip"
-cp ${distributions}/*.zip ./$OUTPUT/plugins
-
-notifZipPath=$(find . -path \*notifications/build/distributions/*.zip)
-distributions="$(dirname "${notifZipPath}")"
-echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

This is an updated build.sh from https://github.com/opensearch-project/opensearch-build/pull/1956 that publishes more than 1 ZIP. Will remove it from that PR.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/1950
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
