### PR TITLE
Added distribution build scripts.

### DIFF
--- a/notifications/core/scripts/build.sh
+++ b/notifications/core/scripts/build.sh
@@ -70,10 +70,10 @@ fi
 mkdir -p $OUTPUT/maven
 mkdir -p $OUTPUT/plugins
 
-./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+../gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+../gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
-zipPath=$(find . -path \*notifications/build/distributions/*.zip)
+zipPath=$(find . -path \*/build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
 echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Alternative to #402 in support of https://github.com/opensearch-project/opensearch-build/pull/1957

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/1950
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
