### PR TITLE
Support sending email message via Notifications passthrough API

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -301,7 +301,7 @@ object SendMessageActionHelper {
                     val emailRecipientStatus: List<EmailRecipientStatus> = recipients.map {
                         async(Dispatchers.IO) {
                             val destination = SmtpDestination(
-                                baseMessage.channelName,
+                                baseMessage.accountName,
                                 baseMessage.host,
                                 baseMessage.port,
                                 baseMessage.method,


### PR DESCRIPTION
### Description
Depends on https://github.com/opensearch-project/common-utils/pull/158 so GitHub Actions are expected to fail until that is merged in.

This PR includes the following:
* Changes needed from the Notification plugin side to support sending email notification via the passthrough API for Alerting.
* Fixes the fallback settings for the `EMAIL_USERNAME` and `EMAIL_PASSWORD` to correctly use Alerting's when they aren't set for an SMTP email account
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
