### PR TITLE
Drop java 14, add 17 in test workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,11 @@
 ### Description
 [Describe what this change achieves]
- 
+
 ### Issues Resolved
 [List any issues this PR will resolve]
- 
+
 ### Check List
-- [ ] New functionality includes testing.
-  - [ ] All tests pass, including unit test, integration test and doctest
-- [ ] New functionality has been documented.
-  - [ ] New functionality has javadoc added
-  - [ ] New functionality has user manual doc added
-- [ ] Commits are signed per the DCO using --signoff 
+- [ ] Commits are signed per the DCO using --signoff
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -7,18 +7,21 @@ name: Test and Build Notifications
 
 on: [push, pull_request]
 
-env:
-  OPENSEARCH_VERSION: '2.0.0-SNAPSHOT'
-
 jobs:
   build:
+    strategy:
+      # This setting says that all jobs should finish, even if one fails
+      fail-fast: false
+      matrix:
+        java: [11, 17]
+
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 1.14
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 1.14
+          java-version: ${{ matrix.java }}
 
       # notifications
       - name: Checkout Notifications


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Issues Resolved
https://github.com/opensearch-project/opensearch-plugins/issues/132
https://github.com/opensearch-project/opensearch-plugins/issues/129

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
