### PR TITLE
Allow ADMIN to access all documents and treat no backend roles as public

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccessManager.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/security/UserAccessManager.kt
@@ -14,6 +14,8 @@ import org.opensearch.rest.RestStatus
  * Class for checking/filtering user access.
  */
 internal object UserAccessManager : UserAccess {
+    const val ADMIN_ROLE = "all_access"
+
     /**
      * {@inheritDoc}
      */
@@ -40,7 +42,7 @@ internal object UserAccessManager : UserAccess {
      * {@inheritDoc}
      */
     override fun getSearchAccessInfo(user: User?): List<String> {
-        if (user == null || !PluginSettings.isRbacEnabled()) { // Filtering is disabled
+        if (user == null || !PluginSettings.isRbacEnabled() || user.roles.contains(ADMIN_ROLE)) { // Filtering is disabled
             return listOf()
         }
         return user.backendRoles
@@ -53,7 +55,9 @@ internal object UserAccessManager : UserAccess {
         if (user == null || !PluginSettings.isRbacEnabled()) { // Filtering is disabled
             return true
         }
-        return user.backendRoles.any { it in access }
+        // User has access to resource if resource is public i.e. no access roles attached, user is an admin user or there is any intersection
+        // between user backend roles and access roles
+        return access.isEmpty() || user.roles.contains(ADMIN_ROLE) || user.backendRoles.any { it in access }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

### Description
N/A

### Issues Resolved
* Fix backend role filtering to allow access to all documents to ADMIN users
* Fix backend role filtering to consider documents that are empty access 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
