### PR TITLE
Add Json Dependency to build.gradle

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
     implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    implementation group: 'com.eclipsesource.minimal-json', name: 'minimal-json', version: '0.9.2'
     compileOnly project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')
 }
 


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

### Description
This change adds the dependencies of the `JsonUnflattener` to the gradle project. 

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/417

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
