### PR TITLE
Disabling stats API

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -63,7 +63,14 @@ dependencies {
         exclude group: 'org.jetbrains', module: 'annotations' // resolve jarhell
     } // ${kotlin_version} does not work for coroutines
     implementation "${group}:common-utils:${common_utils_version}"
-    implementation "org.json:json:20180813"
+    // TODO: change compile to implementation when the _local/stats API is supported
+    compileOnly "org.json:json:20180813"
+    compileOnly "com.github.wnameless.json:json-flattener:0.13.0"
+    // TODO: uncomment when the _local/stats API is supported
+    // implementation "com.github.wnameless.json:json-base:2.0.0"
+    // implementation "com.fasterxml.jackson.core:jackson-databind:2.10.4"
+    // implementation "com.fasterxml.jackson.core:jackson-annotations:2.10.4"
+
 
     testImplementation(
             'org.assertj:assertj-core:3.19.0',
@@ -87,7 +94,6 @@ dependencies {
     testImplementation 'com.google.code.gson:gson:2.8.7'
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'
-    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
     compileOnly project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')
 }
 

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -36,7 +36,6 @@ import org.opensearch.notifications.index.NotificationConfigIndex
 import org.opensearch.notifications.resthandler.NotificationChannelListRestHandler
 import org.opensearch.notifications.resthandler.NotificationConfigRestHandler
 import org.opensearch.notifications.resthandler.NotificationFeaturesRestHandler
-import org.opensearch.notifications.resthandler.NotificationStatsRestHandler
 import org.opensearch.notifications.resthandler.SendTestMessageRestHandler
 import org.opensearch.notifications.security.UserAccessManager
 import org.opensearch.notifications.send.SendMessageActionHelper
@@ -166,7 +165,7 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension {
             NotificationFeaturesRestHandler(),
             NotificationChannelListRestHandler(),
             SendTestMessageRestHandler(),
-            NotificationStatsRestHandler()
+            // NotificationStatsRestHandler()
         )
     }
 


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

### Description
* Disabling stats API as it doesn't make sense in the current form - returning per node stats is misleading as different requests will result in different data based on the node handling the requests. We should either consolidate from all nodes or we should have a mechanism to sync these across nodes to make it useful

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
