### PR TITLE
Replace checked-in ZIPs with dynamic dependencies

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -178,14 +178,19 @@ integTest {
     }
 }
 
+project.getTasks().getByName("bundlePlugin").dependsOn(findProject(":${rootProject.name}-core").tasks.getByPath(":${rootProject.name}-core:build"))
 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
+Zip coreBundle = (Zip) findProject(":${rootProject.name}-core").getTasks().getByName("bundlePlugin");
 integTest.dependsOn(bundle)
-integTest.getClusters().forEach{c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))}
+integTest.getClusters().forEach{c -> {
+    c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))
+    c.plugin(project.getObjects().fileProperty().value(coreBundle.getArchiveFile()))
+}}
 
 testClusters.integTest {
     testDistribution = 'INTEG_TEST'
     // need to install notification-core first, need to assemble notification-core first
-    plugin(provider(new Callable<RegularFile>(){
+/*    plugin(provider(new Callable<RegularFile>(){
         @Override
         RegularFile call() throws Exception {
             return new RegularFile() {
@@ -195,7 +200,7 @@ testClusters.integTest {
                 }
             }
         }
-    }))
+    }))*/
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -189,18 +189,7 @@ integTest.getClusters().forEach{c -> {
 
 testClusters.integTest {
     testDistribution = 'INTEG_TEST'
-    // need to install notification-core first, need to assemble notification-core first
-/*    plugin(provider(new Callable<RegularFile>(){
-        @Override
-        RegularFile call() throws Exception {
-            return new RegularFile() {
-                @Override
-                File getAsFile() {
-                    return fileTree("src/test/resources/notifications-core").getSingleFile()
-                }
-            }
-        }
-    }))*/
+
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
Replace checked-in ZIP for bwc tests with a dynamic dependency

### Issues Resolved
[Replace checked-in ZIPs with dynamic dependencies](https://github.com/opensearch-project/notifications/issues/415)

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
