### PR TITLE
Make use of suspendCoroutine to remove blocking calls to OpenSearch client

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/CreateNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/CreateNotificationConfigAction.kt
@@ -53,7 +53,7 @@ internal class CreateNotificationConfigAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: CreateNotificationConfigRequest,
         user: User?
     ): CreateNotificationConfigResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/DeleteNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/DeleteNotificationConfigAction.kt
@@ -53,7 +53,7 @@ internal class DeleteNotificationConfigAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: DeleteNotificationConfigRequest,
         user: User?
     ): DeleteNotificationConfigResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetChannelListAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetChannelListAction.kt
@@ -53,7 +53,7 @@ internal class GetChannelListAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: GetChannelListRequest,
         user: User?
     ): GetChannelListResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetNotificationConfigAction.kt
@@ -53,7 +53,7 @@ internal class GetNotificationConfigAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: GetNotificationConfigRequest,
         user: User?
     ): GetNotificationConfigResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
@@ -53,7 +53,7 @@ internal class GetPluginFeaturesAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: GetPluginFeaturesRequest,
         user: User?
     ): GetPluginFeaturesResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PluginBaseAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PluginBaseAction.kt
@@ -113,7 +113,7 @@ internal abstract class PluginBaseAction<Request : ActionRequest, Response : Act
      * @param user the user context given by security plugin
      * @return the response to return.
      */
-    abstract fun executeRequest(request: Request, user: User?): Response
+    abstract suspend fun executeRequest(request: Request, user: User?): Response
 
     /**
      * Executes the given [block] function on this resource and then closes it down correctly whether an exception

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PublishNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PublishNotificationAction.kt
@@ -57,7 +57,7 @@ internal class PublishNotificationAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: LegacyPublishNotificationRequest,
         user: User?
     ): LegacyPublishNotificationResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendNotificationAction.kt
@@ -53,7 +53,7 @@ internal class SendNotificationAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: SendNotificationRequest,
         user: User?
     ): SendNotificationResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/UpdateNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/UpdateNotificationConfigAction.kt
@@ -53,7 +53,7 @@ internal class UpdateNotificationConfigAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(
+    override suspend fun executeRequest(
         request: UpdateNotificationConfigRequest,
         user: User?
     ): UpdateNotificationConfigResponse {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -5,11 +5,7 @@
 
 package org.opensearch.notifications.index
 
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withTimeout
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.action.ActionListener
-import org.opensearch.client.OpenSearchClient
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
@@ -43,8 +39,6 @@ import org.opensearch.notifications.model.NotificationConfigDoc
 import org.opensearch.notifications.security.UserAccess
 import org.opensearch.rest.RestStatus
 import java.time.Instant
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * NotificationConfig indexing operation actions.
@@ -464,20 +458,5 @@ object ConfigIndexingActions {
         } else {
             delete(request.configIds, user)
         }
-    }
-    suspend fun <C : OpenSearchClient, T> C.suspendUntil(block: C.(ActionListener<T>) -> Unit): T =
-        suspendCancellableCoroutine { cont ->
-            block(object : ActionListener<T> {
-                override fun onResponse(response: T) = cont.resume(response)
-
-                override fun onFailure(e: Exception) = cont.resumeWithException(e)
-            })
-        }
-    suspend fun <C : OpenSearchClient, T> C.suspendUntilTimeout(timeout: Long, block: C.(ActionListener<T>) -> Unit): T {
-        var finalValue: T
-        withTimeout(timeout) {
-            finalValue = suspendUntil(block)
-        }
-        return finalValue
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigOperations.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigOperations.kt
@@ -21,21 +21,21 @@ interface ConfigOperations {
      * @return Notification Config id if successful, null otherwise
      * @throws java.util.concurrent.ExecutionException with a cause
      */
-    fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String? = null): String?
+    suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String? = null): String?
 
     /**
      * Query index for Notification Config with ID
      * @param ids set of the document ids to get info
      * @return list of NotificationConfigDocInfo on success, null otherwise
      */
-    fun getNotificationConfigs(ids: Set<String>): List<NotificationConfigDocInfo>
+    suspend fun getNotificationConfigs(ids: Set<String>): List<NotificationConfigDocInfo>
 
     /**
      * Query index for Notification Config with ID
      * @param id the id for the document
      * @return NotificationConfigDocInfo on success, null otherwise
      */
-    fun getNotificationConfig(id: String): NotificationConfigDocInfo?
+    suspend fun getNotificationConfig(id: String): NotificationConfigDocInfo?
 
     /**
      * Query index for NotificationConfigDocs for given access details
@@ -43,7 +43,7 @@ interface ConfigOperations {
      * @param request [GetNotificationConfigRequest] object
      * @return search result of NotificationConfigDocs
      */
-    fun getAllNotificationConfigs(
+    suspend fun getAllNotificationConfigs(
         access: List<String>,
         request: GetNotificationConfigRequest
     ): NotificationConfigSearchResult
@@ -54,19 +54,19 @@ interface ConfigOperations {
      * @param notificationConfigDoc the NotificationConfigDoc data
      * @return true if successful, false otherwise
      */
-    fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean
+    suspend fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean
 
     /**
      * delete NotificationConfigDoc for given id
      * @param id the id for the document
      * @return true if successful, false otherwise
      */
-    fun deleteNotificationConfig(id: String): Boolean
+    suspend fun deleteNotificationConfig(id: String): Boolean
 
     /**
      * delete NotificationConfigDoc for given ids
      * @param ids set of the document ids to delete
      * @return map of id to status
      */
-    fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus>
+    suspend fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus>
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -35,7 +35,6 @@ import org.opensearch.commons.notifications.model.SearchResults
 import org.opensearch.commons.utils.logger
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
-import org.opensearch.notifications.index.ConfigIndexingActions.suspendUntilTimeout
 import org.opensearch.notifications.index.ConfigQueryHelper.getSortField
 import org.opensearch.notifications.model.DocInfo
 import org.opensearch.notifications.model.DocMetadata.Companion.ACCESS_LIST_TAG
@@ -44,6 +43,7 @@ import org.opensearch.notifications.model.NotificationConfigDoc
 import org.opensearch.notifications.model.NotificationConfigDocInfo
 import org.opensearch.notifications.settings.PluginSettings
 import org.opensearch.notifications.util.SecureIndexClient
+import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntilTimeout
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.SearchHit
 import org.opensearch.search.builder.SearchSourceBuilder

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -8,13 +8,19 @@ package org.opensearch.notifications.index
 import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.action.DocWriteResponse
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
+import org.opensearch.action.admin.indices.create.CreateIndexResponse
 import org.opensearch.action.bulk.BulkRequest
+import org.opensearch.action.bulk.BulkResponse
 import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.get.MultiGetRequest
+import org.opensearch.action.get.MultiGetResponse
 import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
@@ -29,6 +35,7 @@ import org.opensearch.commons.notifications.model.SearchResults
 import org.opensearch.commons.utils.logger
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.index.ConfigIndexingActions.suspendUntilTimeout
 import org.opensearch.notifications.index.ConfigQueryHelper.getSortField
 import org.opensearch.notifications.model.DocInfo
 import org.opensearch.notifications.model.DocMetadata.Companion.ACCESS_LIST_TAG
@@ -86,7 +93,7 @@ internal object NotificationConfigIndex : ConfigOperations {
      * Create index using the mapping and settings defined in resource
      */
     @Suppress("TooGenericExceptionCaught")
-    private fun createIndex() {
+    private suspend fun createIndex() {
         if (!isIndexExists()) {
             val classLoader = NotificationConfigIndex::class.java.classLoader
             val indexMappingSource = classLoader.getResource(MAPPING_FILE_NAME)?.readText()!!
@@ -96,8 +103,9 @@ internal object NotificationConfigIndex : ConfigOperations {
                 .mapping(indexMappingAsMap)
                 .settings(indexSettingsSource, XContentType.YAML)
             try {
-                val actionFuture = client.admin().indices().create(request)
-                val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+                val response: CreateIndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                    admin().indices().create(request, it)
+                }
                 if (response.isAcknowledged) {
                     log.info("$LOG_PREFIX:Index $INDEX_NAME creation Acknowledged")
                 } else {
@@ -123,7 +131,7 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {
+    override suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {
         createIndex()
         val indexRequest = IndexRequest(INDEX_NAME)
             .source(configDoc.toXContent())
@@ -131,8 +139,9 @@ internal object NotificationConfigIndex : ConfigOperations {
         if (id != null) {
             indexRequest.id(id)
         }
-        val actionFuture = client.index(indexRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: IndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            index(indexRequest, it)
+        }
         return if (response.result != DocWriteResponse.Result.CREATED) {
             log.warn("$LOG_PREFIX:createNotificationConfig - response:$response")
             null
@@ -144,23 +153,25 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun getNotificationConfigs(ids: Set<String>): List<NotificationConfigDocInfo> {
+    override suspend fun getNotificationConfigs(ids: Set<String>): List<NotificationConfigDocInfo> {
         createIndex()
         val getRequest = MultiGetRequest()
         ids.forEach { getRequest.add(INDEX_NAME, it) }
-        val actionFuture = client.multiGet(getRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: MultiGetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            multiGet(getRequest, it)
+        }
         return response.responses.mapNotNull { parseNotificationConfigDoc(it.id, it.response) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun getNotificationConfig(id: String): NotificationConfigDocInfo? {
+    override suspend fun getNotificationConfig(id: String): NotificationConfigDocInfo? {
         createIndex()
         val getRequest = GetRequest(INDEX_NAME).id(id)
-        val actionFuture = client.get(getRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: GetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            get(getRequest, it)
+        }
         return parseNotificationConfigDoc(id, response)
     }
 
@@ -189,7 +200,7 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun getAllNotificationConfigs(
+    override suspend fun getAllNotificationConfigs(
         access: List<String>,
         request: GetNotificationConfigRequest
     ): NotificationConfigSearchResult {
@@ -208,8 +219,9 @@ internal object NotificationConfigIndex : ConfigOperations {
         val searchRequest = SearchRequest()
             .indices(INDEX_NAME)
             .source(sourceBuilder)
-        val actionFuture = client.search(searchRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: SearchResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            search(searchRequest, it)
+        }
         val result = NotificationConfigSearchResult(request.fromIndex.toLong(), response, searchHitParser)
         log.info(
             "$LOG_PREFIX:getAllNotificationConfigs from:${request.fromIndex}, maxItems:${request.maxItems}," +
@@ -222,14 +234,15 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean {
+    override suspend fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean {
         createIndex()
         val indexRequest = IndexRequest(INDEX_NAME)
             .source(notificationConfigDoc.toXContent())
             .create(false)
             .id(id)
-        val actionFuture = client.index(indexRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: IndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            index(indexRequest, it)
+        }
         if (response.result != DocWriteResponse.Result.UPDATED) {
             log.warn("$LOG_PREFIX:updateNotificationConfig failed for $id; response:$response")
         }
@@ -239,13 +252,15 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun deleteNotificationConfig(id: String): Boolean {
+    override suspend fun deleteNotificationConfig(id: String): Boolean {
         createIndex()
         val deleteRequest = DeleteRequest()
             .index(INDEX_NAME)
             .id(id)
-        val actionFuture = client.delete(deleteRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+
+        val response: DeleteResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            delete(deleteRequest, it)
+        }
         if (response.result != DocWriteResponse.Result.DELETED) {
             log.warn("$LOG_PREFIX:deleteNotificationConfig failed for $id; response:$response")
         }
@@ -255,7 +270,7 @@ internal object NotificationConfigIndex : ConfigOperations {
     /**
      * {@inheritDoc}
      */
-    override fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus> {
+    override suspend fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus> {
         createIndex()
         val bulkRequest = BulkRequest()
         ids.forEach {
@@ -264,8 +279,9 @@ internal object NotificationConfigIndex : ConfigOperations {
                 .id(it)
             bulkRequest.add(deleteRequest)
         }
-        val actionFuture = client.bulk(bulkRequest)
-        val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+        val response: BulkResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            bulk(bulkRequest, it)
+        }
         val mutableMap = mutableMapOf<String, RestStatus>()
         response.forEach {
             mutableMap[it.id] = it.status()

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -74,7 +74,7 @@ object SendMessageActionHelper {
      * Send notification message and keep audit.
      * @param request request object
      */
-    fun executeRequest(request: SendNotificationRequest): SendNotificationResponse {
+    suspend fun executeRequest(request: SendNotificationRequest): SendNotificationResponse {
         val eventSource = request.eventSource
         val channelMessage = request.channelMessage
         val channelIds = request.channelIds.toSet()
@@ -605,7 +605,7 @@ object SendMessageActionHelper {
      * @param configIds config id set
      * @return map of config id to [NotificationConfigDocInfo]
      */
-    private fun getConfigs(configIds: Set<String>): Map<String, NotificationConfigDocInfo?> {
+    private suspend fun getConfigs(configIds: Set<String>): Map<String, NotificationConfigDocInfo?> {
         return when (configIds.size) {
             0 -> emptyMap()
             1 -> getSingleConfig(configIds.first())
@@ -618,7 +618,7 @@ object SendMessageActionHelper {
      * @param configIds config id set
      * @return map of config id to [NotificationConfigDocInfo]
      */
-    private fun getAllConfigs(configIds: Set<String>): Map<String, NotificationConfigDocInfo?> {
+    private suspend fun getAllConfigs(configIds: Set<String>): Map<String, NotificationConfigDocInfo?> {
         log.info("$LOG_PREFIX:getAllConfigs-get $configIds")
         val configDocs = configOperations.getNotificationConfigs(configIds)
         val configMap = mutableMapOf<String, NotificationConfigDocInfo?>()
@@ -636,7 +636,7 @@ object SendMessageActionHelper {
      * @param configId config id
      * @return map of config id to [NotificationConfigDocInfo]
      */
-    private fun getSingleConfig(configId: String): Map<String, NotificationConfigDocInfo?> {
+    private suspend fun getSingleConfig(configId: String): Map<String, NotificationConfigDocInfo?> {
         log.info("$LOG_PREFIX:getSingleConfig-get $configId")
         val configDoc = configOperations.getNotificationConfig(configId)
         return mapOf(configId to configDoc)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SuspendUtils.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SuspendUtils.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.notifications.util
 
 import kotlinx.coroutines.suspendCancellableCoroutine

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SuspendUtils.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SuspendUtils.kt
@@ -1,0 +1,32 @@
+package org.opensearch.notifications.util
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import org.opensearch.action.ActionListener
+import org.opensearch.client.OpenSearchClient
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class SuspendUtils {
+    companion object {
+        suspend fun <C : OpenSearchClient, T> C.suspendUntil(block: C.(ActionListener<T>) -> Unit): T =
+            suspendCancellableCoroutine { cont ->
+                block(object : ActionListener<T> {
+                    override fun onResponse(response: T) = cont.resume(response)
+
+                    override fun onFailure(e: Exception) = cont.resumeWithException(e)
+                })
+            }
+
+        suspend fun <C : OpenSearchClient, T> C.suspendUntilTimeout(
+            timeout: Long,
+            block: C.(ActionListener<T>) -> Unit
+        ): T {
+            var finalValue: T
+            withTimeout(timeout) {
+                finalValue = suspendUntil(block)
+            }
+            return finalValue
+        }
+    }
+}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -6,6 +6,7 @@ package org.opensearch.notifications.action
 
 import io.mockk.every
 import io.mockk.mockkObject
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.fail
@@ -75,7 +76,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(ConfigIndexingActions)
-        every { ConfigIndexingActions.create(request, any()) } returns response
+        every {
+            runBlocking {
+                ConfigIndexingActions.create(request, any())
+            }
+        } returns response
 
         val createNotificationConfigAction = CreateNotificationConfigAction(
             transportService, client, actionFilters, xContentRegistry
@@ -91,7 +96,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(ConfigIndexingActions)
-        every { ConfigIndexingActions.update(request, any()) } returns response
+        every {
+            runBlocking {
+                ConfigIndexingActions.update(request, any())
+            }
+        } returns response
 
         val updateNotificationConfigAction = UpdateNotificationConfigAction(
             transportService, client, actionFilters, xContentRegistry
@@ -108,7 +117,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(ConfigIndexingActions)
-        every { ConfigIndexingActions.delete(request, any()) } returns response
+        every {
+            runBlocking {
+                ConfigIndexingActions.delete(request, any())
+            }
+        } returns response
 
         val deleteNotificationConfigAction = DeleteNotificationConfigAction(
             transportService, client, actionFilters, xContentRegistry
@@ -125,7 +138,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(ConfigIndexingActions)
-        every { ConfigIndexingActions.get(request, any()) } returns response
+        every {
+            runBlocking {
+                ConfigIndexingActions.get(request, any())
+            }
+        } returns response
 
         val getNotificationConfigAction = GetNotificationConfigAction(
             transportService, client, actionFilters, xContentRegistry
@@ -153,7 +170,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(ConfigIndexingActions)
-        every { ConfigIndexingActions.getChannelList(request, any()) } returns response
+        every {
+            runBlocking {
+                ConfigIndexingActions.getChannelList(request, any())
+            }
+        } returns response
 
         val getChannelListAction = GetChannelListAction(
             transportService, client, actionFilters, xContentRegistry
@@ -184,7 +205,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(SendMessageActionHelper)
-        every { SendMessageActionHelper.executeRequest(request) } returns response
+        every {
+            runBlocking {
+                SendMessageActionHelper.executeRequest(request)
+            }
+        } returns response
 
         val sendNotificationAction = SendNotificationAction(
             transportService, client, actionFilters, xContentRegistry

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/SuspendUtilsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/SuspendUtilsTests.kt
@@ -1,0 +1,48 @@
+package org.opensearch.notifications.util
+
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Answers
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
+import org.opensearch.client.Client
+import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntilTimeout
+
+@ExtendWith(MockitoExtension::class)
+internal class SuspendUtilsTests {
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private lateinit var client: Client
+
+    @Mock
+    lateinit var mockedIndexRequest: IndexRequest
+
+    @Test
+    fun `test SuspendUntilTimeout TimeoutCancellationException`() {
+        runBlocking {
+            assertThrows<TimeoutCancellationException> {
+                // setting low timeout to always timeout
+                client.suspendUntilTimeout<Client, IndexResponse>(0) {
+                    client.index(mockedIndexRequest)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test SuspendUntilTimeout RuntimeException`() {
+        runBlocking {
+            whenever(client.index(mockedIndexRequest)).thenThrow(RuntimeException())
+            assertThrows<RuntimeException> {
+                client.suspendUntilTimeout<Client, IndexResponse>(1000) {
+                    client.index(mockedIndexRequest)
+                }
+            }
+        }
+    }
+}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/SuspendUtilsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/SuspendUtilsTests.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.notifications.util
 
 import com.nhaarman.mockitokotlin2.whenever


### PR DESCRIPTION
### Description
The ActionGet on ActionFuture is a blocking call. Making use of `SuspendCoroutine` to transform the blocking call to suspend by making use of `OpenSearchClient` `ActionListener` interface.
### Issues Resolved 
It partly addresses https://github.com/opensearch-project/notifications/issues/267
### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
