### PR TITLE
Fix SNS Channel

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -82,9 +82,9 @@ configurations.all {
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
         force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-core:2.11.4" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-annotations:2.11.4" // resolve for amazonaws
-        force "com.fasterxml.jackson.core:jackson-databind:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4" // resolve for amazonaws
@@ -101,6 +101,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.apache.httpcomponents:httpcore:4.4.5"
     implementation "org.apache.httpcomponents:httpclient:4.5.10"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sts:${aws_version}"

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/credentials/oss/CredentialsProviderFactory.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/credentials/oss/CredentialsProviderFactory.kt
@@ -9,12 +9,12 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest
 import org.opensearch.notifications.core.credentials.CredentialsProvider
 
 class CredentialsProviderFactory : CredentialsProvider {
+
     override fun getCredentialsProvider(region: String, roleArn: String?): AWSCredentialsProvider {
         return if (roleArn != null) {
             getCredentialsProviderByIAMRole(region, roleArn)
@@ -25,7 +25,7 @@ class CredentialsProviderFactory : CredentialsProvider {
 
     private fun getCredentialsProviderByIAMRole(region: String, roleArn: String?): AWSCredentialsProvider {
         val stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-            .withCredentials(ProfileCredentialsProvider())
+            .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
             .withRegion(region)
             .build()
         val roleRequest = AssumeRoleRequest()

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     compileOnly "com.github.wnameless.json:json-flattener:0.13.0"
     // TODO: uncomment when the _local/stats API is supported
     // implementation "com.github.wnameless.json:json-base:2.0.0"
-    // implementation "com.fasterxml.jackson.core:jackson-databind:2.10.4"
+    // implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     // implementation "com.fasterxml.jackson.core:jackson-annotations:2.10.4"
 
 


### PR DESCRIPTION
### Description
* Adds `jackson-databind` and `jackson-annotations` as runtime dependencies for Notifications Core which is needed for SNS (not having it throws a classloader exception at runtime)
* Favor using OpenSearch's versions of jackson and jackson-databind when resolving conflicts with AWS SDK
* Switch to using the `DefaultAWSCredentialsProviderChain` for STS credentials as it's more flexible and recommended

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
