### PR TITLE
Removed rc1 qualifier from front and backend plugin versions.

### DIFF
--- a/dashboards-notifications/opensearch_dashboards.json
+++ b/dashboards-notifications/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "notificationsDashboards",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "opensearchDashboardsVersion": "2.0.0",
   "requiredPlugins": ["navigation", "data"],
   "optionalPlugins": ["share"],

--- a/dashboards-notifications/package.json
+++ b/dashboards-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-dashboards",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "description": "OpenSearch Dashboards Notifications Plugin",
   "license": "Apache-2.0",
   "main": "index.ts",

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,10 +6,10 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
-        // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        // 2.0.0-SNAPSHOT -> 2.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         if (buildVersionQualifier) {


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Cherry-picked commits from `main` to `2.0`.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
