### PR TITLE
Update sender name validation to allow underscores

### DIFF
--- a/dashboards-notifications/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<CreateSESSenderForm/> spec renders errors 1`] = `
       class="euiFormHelpText euiFormRow__text"
       id="random_html_id-help-0"
     >
-      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen).
+      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore).
     </div>
   </div>
 </div>
@@ -95,7 +95,7 @@ exports[`<CreateSESSenderForm/> spec renders the component 1`] = `
       class="euiFormHelpText euiFormRow__text"
       id="random_html_id-help-0"
     >
-      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen).
+      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore).
     </div>
   </div>
 </div>

--- a/dashboards-notifications/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
+++ b/dashboards-notifications/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<CreateSenderForm/> spec renders errors 1`] = `
       class="euiFormHelpText euiFormRow__text"
       id="random_html_id-help-0"
     >
-      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen).
+      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore).
     </div>
   </div>
 </div>
@@ -95,7 +95,7 @@ exports[`<CreateSenderForm/> spec renders the component 1`] = `
       class="euiFormHelpText euiFormRow__text"
       id="random_html_id-help-0"
     >
-      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen).
+      Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore).
     </div>
   </div>
 </div>

--- a/dashboards-notifications/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
+++ b/dashboards-notifications/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
@@ -39,7 +39,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
       <EuiFormRow
         label="Sender name"
         style={{ maxWidth: '650px' }}
-        helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen)."
+        helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore)."
         error={props.inputErrors.senderName.join(' ')}
         isInvalid={props.inputErrors.senderName.length > 0}
       >

--- a/dashboards-notifications/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/dashboards-notifications/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -54,7 +54,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
       <EuiFormRow
         label="Sender name"
         style={{ maxWidth: '650px' }}
-        helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, and - (hyphen)."
+        helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore)."
         error={props.inputErrors.senderName.join(' ')}
         isInvalid={props.inputErrors.senderName.length > 0}
       >

--- a/dashboards-notifications/public/pages/Emails/utils/validationHelper.ts
+++ b/dashboards-notifications/public/pages/Emails/utils/validationHelper.ts
@@ -14,7 +14,7 @@ export const validateSenderName = (name: string) => {
   }
   if (name.length > 50 || name.length < 2)
     errors.push('Sender name must contain 2 to 50 characters.');
-  if (!/^[a-z0-9-]+$/.test(name))
+  if (!/^[a-z0-9-_]+$/.test(name))
     errors.push('Sender name contains invalid characters.');
   return errors;
 };


### PR DESCRIPTION
### Description
Alerting Email Senders which will be automatically migrated to Notifications used to allow `_` (underscores) in their naming scheme. Since Notifications Dashboards didn't allow this, this could mean that migrated SMTP Senders would have validation failures by default if migrated this way and edited.

This PR updates the validation to allow underscores in the naming scheme since there is no inherit downside to having it.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
