### PR TITLE
Changing the Return Type of SendNotificationsResponse

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -184,7 +184,6 @@ internal class PluginActionTests {
 
     @Test
     fun `Send notification action should call back action listener`() {
-        val notificationId = "notification-1"
         val request = mock(SendNotificationRequest::class.java)
 
         val sampleEventSource = EventSource(


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

### Description
This adds a List of NotificationEvents to the SendMessage API Response. SendMessage APIs response reflects the status of the notifications that have been sent.

Follow up PR: Add IT to test multiple web-hook channels and use the `SendNotifications` API  from the Notifications Plugin. 

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/441

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
