### PR TITLE
Removing error pop-ups checking for event_id

### DIFF
--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -249,15 +249,7 @@ export default class NotificationService {
     const response = await this.httpClient.get(
         `${NODE_API.SEND_TEST_MESSAGE}/${configId}`
     );
-    if (response.event_id != null) {
-      await this.getNotification(response.event_id).then((response) => {
-        if (!response.success) {
-          const error = new Error('Failed to send the test message.');
-          error.stack = JSON.stringify(response.status_list, null, 2);
-          throw error;
-        }
-      });
-    } else {
+    if (response.status_list[0].delivery_status.status_code != 200) {
       console.error(response);
       const error = new Error('Failed to send the test message.');
       error.stack = JSON.stringify(response, null, 2);


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

### Description
Currently, the frontend code is being checked for an `event_id` in response to the Send Notifications Response. This PR removes the check for the `event_id`. 

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/441

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
