### PR TITLE
Use OpenSearch's versions for httpclient and httpcore

### DIFF
--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-ses:${aws_version}"
-    implementation "org.apache.httpcomponents:httpcore:4.4.13"
-    implementation "org.apache.httpcomponents:httpclient:4.5.10"
+    implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation(
@@ -69,8 +69,8 @@ configurations.all {
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
         force "commons-logging:commons-logging:${versions.commonslogging}" // resolve for amazonaws
         force "commons-codec:commons-codec:1.13" // resolve for amazonaws
-        force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
-        force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpclient:${versions.httpclient}" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpcore:${versions.httpcore}" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-annotations:2.11.4" // resolve for amazonaws

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -79,8 +79,8 @@ configurations.all {
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
         force "commons-logging:commons-logging:${versions.commonslogging}" // resolve for amazonaws
         force "commons-codec:commons-codec:1.13" // resolve for amazonaws
-        force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for amazonaws
-        force "org.apache.httpcomponents:httpcore:4.4.13" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpclient:${versions.httpclient}" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpcore:${versions.httpcore}" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}" // resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}" // resolve for amazonaws
@@ -99,8 +99,8 @@ dependencies {
     implementation "commons-logging:commons-logging:${versions.commonslogging}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-    implementation "org.apache.httpcomponents:httpcore:4.4.5"
-    implementation "org.apache.httpcomponents:httpclient:4.5.10"
+    implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Update `httpclient` and `httpcore` dependencies to use OpenSearch's versions. At the time of this PR, the versions being used are the following:
```
httpclient        = 4.5.13
httpcore          = 4.4.12
```

### Issues Resolved
#354

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
