### PR TITLE
Run Cypress tests as part of Notifications Dashboards GitHub Action workflow

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -10,17 +10,31 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: notifications-dashboards
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_PLUGIN_VERSION: 2.1.0.0
+  OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
     steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          # TODO: Parse this from alerting plugin
+          java-version: 14
+
       - name: Checkout Plugin
         uses: actions/checkout@v1
+
+      - name: Run Opensearch with plugin
+        run: |
+          cd notifications
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
+          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
 
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v1
@@ -50,17 +64,48 @@ jobs:
       - name: Move Notifications to Plugins Dir
         run: mv dashboards-notifications OpenSearch-Dashboards/plugins/dashboards-notifications
 
-      - name: OpenSearch Dashboards Pluign Bootstrap
+      - name: OpenSearch Dashboards Plugin Bootstrap
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-notifications
           yarn osd bootstrap
 
-      - name: Test
+      - name: Build Artifact
+        run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-notifications
+          yarn build
+
+      - name: Run unit tests
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 1
           command: cd OpenSearch-Dashboards/plugins/dashboards-notifications; yarn test:jest --coverage
+
+      - name: Run OpenSearch Dashboards server
+        run: |
+          cd OpenSearch-Dashboards
+          yarn start --no-base-path --no-watch &
+          sleep 300
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: OpenSearch-Dashboards/plugins/dashboards-notifications
+          command: yarn run cypress run
+
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/screenshots
+
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: cypress-videos
+        path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/videos
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -68,11 +113,6 @@ jobs:
           flags: dashboards-notifications
           directory: OpenSearch-Dashboards/plugins/
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Build Artifact
-        run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-notifications
-          yarn build
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          # TODO: Parse this from alerting plugin
-          java-version: 14
+          # TODO: Parse this from notifications plugin
+          java-version: 11
 
       - name: Checkout Plugin
         uses: actions/checkout@v1

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -13,7 +13,7 @@ env:
   OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     env:
       # prevents extra Cypress installation progress messages
@@ -95,17 +95,17 @@ jobs:
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: cypress-screenshots
-        path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/screenshots
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
-      if: always()
-      with:
-        name: cypress-videos
-        path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/videos
+        if: always()
+        with:
+          name: cypress-videos
+          path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/videos
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -119,4 +119,3 @@ jobs:
         with:
           name: dashboards-notifications
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/build
-

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -98,14 +98,14 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/screenshots
+          path: OpenSearch-Dashboards/plugins/dashboards-notifications/.cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-videos
-          path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/videos
+          path: OpenSearch-Dashboards/plugins/dashboards-notifications/.cypress/videos
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Run Cypress end to end tests as part of GitHub Action workflow which previously only ran the Jest unit test. This should provide more comprehensive test coverage in the CI.

### Issues Resolved
#412 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
