### PR TITLE
Add tasks to publish zips for Notifications and Notifications Core plugins

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -20,6 +20,7 @@ repositories {
 }
 
 apply plugin: 'opensearch.opensearchplugin'
+apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.java'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-rest-test'
@@ -36,6 +37,29 @@ opensearchplugin {
     name 'opensearch-notifications-core'
     description 'OpenSearch Notifications Core Plugin'
     classname 'org.opensearch.notifications.core.NotificationCorePlugin'
+}
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = "opensearch-notifications-core"
+                description = "OpenSearch Notifications Core Plugin"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/notifications"
+                    }
+                }
+            }
+        }
+    }
 }
 
 task integTest(type: RestIntegTestTask) {

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
+apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
@@ -32,6 +33,29 @@ opensearchplugin {
     description 'OpenSearch Notifications Plugin'
     classname 'org.opensearch.notifications.NotificationPlugin'
     extendedPlugins = ['opensearch-notifications-core']
+}
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = "opensearch-notifications"
+                description = "OpenSearch Notifications Plugin"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/notifications"
+                    }
+                }
+            }
+        }
+    }
 }
 
 allOpen {


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Publish Notifications and Notifications Core zips to maven repo.

### Issues Resolved
#474 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
