### PR TITLE
Bump 2.x branch to 2.2.0

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -10,7 +10,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: notifications-dashboards
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
 
 jobs:
   tests:

--- a/dashboards-notifications/opensearch_dashboards.json
+++ b/dashboards-notifications/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "notificationsDashboards",
-  "version": "2.1.0.0",
-  "opensearchDashboardsVersion": "2.1.0",
+  "version": "2.2.0.0",
+  "opensearchDashboardsVersion": "2.2.0",
   "requiredPlugins": ["navigation", "data"],
   "optionalPlugins": ["share"],
   "server": true,

--- a/dashboards-notifications/package.json
+++ b/dashboards-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-dashboards",
-  "version": "2.1.0.0",
+  "version": "2.2.0.0",
   "description": "OpenSearch Dashboards Notifications Plugin",
   "license": "Apache-2.0",
   "main": "index.ts",

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,10 +6,10 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
-        // 2.1.0-SNAPSHOT -> 2.1.0.0-SNAPSHOT
+        // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         plugin_no_snapshot = opensearch_build

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
-    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation "org.mockito:mockito-core:4.6.1"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
     implementation project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
     testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
-    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation "org.mockito:mockito-core:4.6.1"
     testImplementation 'com.google.code.gson:gson:2.8.7'
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Bumps `2.x` branch to `2.2.0` which is the current development version for that branch.

### Issues Resolved
Part of https://github.com/opensearch-project/notifications/issues/481 but will not resolve the issue entirely until the other branches are updated

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
