### PR TITLE
Resolve hosts when checking against host deny list

### DIFF
--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -51,15 +51,24 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "com.github.seancfoley:ipaddress:5.3.3"
-    implementation("commons-validator:commons-validator:1.7")
+    implementation "commons-validator:commons-validator:1.7"
 
     testImplementation(
-            'org.junit.jupiter:junit-jupiter-api:5.6.2',
+            "io.mockk:mockk:1.11.0",
+            "io.mockk:mockk-common:1.11.0",
+            "io.mockk:mockk-dsl:1.11.0",
+            "io.mockk:mockk-dsl-jvm:1.11.0",
+            "io.mockk:mockk-agent-api:1.11.0",
+            "io.mockk:mockk-agent-common:1.11.0",
+            "io.mockk:mockk-agent-jvm:1.11.0",
+            "org.junit.jupiter:junit-jupiter-api:5.6.2",
             "org.junit.jupiter:junit-jupiter-params:5.6.2",
-            'org.mockito:mockito-junit-jupiter:3.10.0',
+            "org.mockito:mockito-junit-jupiter:3.10.0",
     )
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
+    testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
@@ -12,6 +12,7 @@ import org.apache.http.client.methods.HttpPost
 import org.apache.http.client.methods.HttpPut
 import org.opensearch.common.Strings
 import org.opensearch.notifications.spi.utils.ValidationHelpers.FQDN_REGEX
+import java.net.InetAddress
 import java.net.URL
 
 private object ValidationHelpers {
@@ -51,7 +52,7 @@ fun isValidUrl(urlString: String): Boolean {
 fun isHostInDenylist(urlString: String, hostDenyList: List<String>): Boolean {
     val url = URL(urlString)
     if (url.host != null) {
-        val ipStr = IPAddressString(url.host)
+        val ipStr = IPAddressString(InetAddress.getByName(url.host).hostAddress)
         for (network in hostDenyList) {
             val netStr = IPAddressString(network)
             if (netStr.contains(ipStr)) {

--- a/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
+++ b/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
@@ -61,14 +61,6 @@ internal class ValidationHelpersTests {
     }
 
     @Test
-    fun `test url in denylist`() {
-        val urls = listOf("https://www.amazon.com", "https://mytest.com", "https://mytest.com")
-        for (url in urls) {
-            assertEquals(false, isHostInDenylist(url, hostDenyList))
-        }
-    }
-
-    @Test
     fun `validator identifies invalid url as invalid`() {
         assertThrows<MalformedURLException> { isValidUrl(INVALID_URL) }
     }

--- a/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
+++ b/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
@@ -5,9 +5,12 @@
 
 package org.opensearch.notifications.spi.utils
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.net.InetAddress
 import java.net.MalformedURLException
 
 internal class ValidationHelpersTests {
@@ -20,7 +23,7 @@ internal class ValidationHelpersTests {
     private val WEBHOOK_URL = "https://test-webhook.com:1234/subdirectory?param1=value1&param2=&param3=value3"
     private val CHIME_URL = "https://domain.com/sample_chime_url#1234567890"
 
-    private val hostDentyList = listOf(
+    private val hostDenyList = listOf(
         "127.0.0.0/8",
         "10.0.0.0/8",
         "172.16.0.0/12",
@@ -41,15 +44,27 @@ internal class ValidationHelpersTests {
             "9.9.9.9"
         )
         for (ip in ips) {
-            assertEquals(true, isHostInDenylist("https://$ip", hostDentyList))
+            assertEquals(true, isHostInDenylist("https://$ip", hostDenyList))
         }
+    }
+
+    @Test
+    fun `test hostname gets resolved to ip for denylist`() {
+        val invalidHost = "invalid.com"
+        mockkStatic(InetAddress::class)
+        every { InetAddress.getByName(invalidHost).hostAddress } returns "10.0.0.1" // 10.0.0.0/8
+        assertEquals(true, isHostInDenylist("https://$invalidHost", hostDenyList))
+
+        val validHost = "valid.com"
+        every { InetAddress.getByName(validHost).hostAddress } returns "174.12.0.0"
+        assertEquals(false, isHostInDenylist("https://$validHost", hostDenyList))
     }
 
     @Test
     fun `test url in denylist`() {
         val urls = listOf("https://www.amazon.com", "https://mytest.com", "https://mytest.com")
         for (url in urls) {
-            assertEquals(false, isHostInDenylist(url, hostDentyList))
+            assertEquals(false, isHostInDenylist(url, hostDenyList))
         }
     }
 

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.notifications.core.destinations
 
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -14,9 +13,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
+import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -26,7 +25,6 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
-import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
@@ -46,14 +44,13 @@ internal class ChimeDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+    }
 
-        @BeforeAll
-        fun setup() {
-            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
-            clearAllMocks()
-            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
-        }
+    @Before
+    fun setup() {
+        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+        mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -14,9 +14,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
-import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -47,7 +47,7 @@ internal class ChimeDestinationTests {
             )
     }
 
-    @Before
+    @BeforeEach
     fun setup() {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -52,7 +52,7 @@ internal class ChimeDestinationTests {
             // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
             clearAllMocks()
             mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { isHostInDenylist(any(), any()) } returns false
+            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
         }
     }
 

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.notifications.core.destinations
 
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity
@@ -13,6 +16,7 @@ import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -22,6 +26,7 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
+import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
@@ -41,6 +46,14 @@ internal class ChimeDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+
+        @BeforeAll
+        fun setup() {
+            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+            clearAllMocks()
+            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+            every { isHostInDenylist(any(), any()) } returns false
+        }
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -6,6 +6,7 @@
 package org.opensearch.notifications.core.destinations
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpPost
@@ -55,21 +56,18 @@ internal class ChimeDestinationTests {
 
     @Test
     fun `test chime message null entity response`() {
-        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
+        val mockHttpClient = mockk<CloseableHttpClient>()
 
         // The DestinationHttpClient replaces a null entity with "{}".
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
         // TODO replace EasyMock in all UTs with mockk which fits Kotlin better
-        val httpResponse: CloseableHttpResponse = EasyMock.createMock(CloseableHttpResponse::class.java)
-        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        val httpResponse = mockk<CloseableHttpResponse>()
+        every { mockHttpClient.execute(any<HttpPost>()) } returns httpResponse
 
-        val mockStatusLine: BasicStatusLine = EasyMock.createMock(BasicStatusLine::class.java)
-        EasyMock.expect(httpResponse.statusLine).andReturn(mockStatusLine)
-        EasyMock.expect(httpResponse.entity).andReturn(null).anyTimes()
-        EasyMock.expect(mockStatusLine.statusCode).andReturn(RestStatus.OK.status)
-        EasyMock.replay(mockHttpClient)
-        EasyMock.replay(httpResponse)
-        EasyMock.replay(mockStatusLine)
+        val mockStatusLine = mockk<BasicStatusLine>()
+        every { httpResponse.statusLine } returns mockStatusLine
+        every { httpResponse.entity } returns null
+        every { mockStatusLine.statusCode } returns RestStatus.OK.status
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationTransport = WebhookDestinationTransport(httpClient)

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.notifications.core.destinations
 
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpPatch
 import org.apache.http.client.methods.HttpPost
@@ -16,6 +19,7 @@ import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -25,6 +29,7 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
+import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
@@ -51,6 +56,14 @@ internal class CustomWebhookDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+
+        @BeforeAll
+        fun setup() {
+            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+            clearAllMocks()
+            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+            every { isHostInDenylist(any(), any()) } returns false
+        }
     }
 
     @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.notifications.core.destinations
 
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -17,9 +16,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
+import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -29,7 +28,6 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
-import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
@@ -56,14 +54,13 @@ internal class CustomWebhookDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+    }
 
-        @BeforeAll
-        fun setup() {
-            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
-            clearAllMocks()
-            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
-        }
+    @Before
+    fun setup() {
+        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+        mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
     }
 
     @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
@@ -16,9 +16,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
-import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -56,7 +56,7 @@ internal class CustomWebhookDestinationTests {
             )
     }
 
-    @Before
+    @BeforeEach
     fun setup() {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
@@ -62,7 +62,7 @@ internal class CustomWebhookDestinationTests {
             // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
             clearAllMocks()
             mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { isHostInDenylist(any(), any()) } returns false
+            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
         }
     }
 

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
@@ -53,7 +53,7 @@ internal class SlackDestinationTests {
             // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
             clearAllMocks()
             mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { isHostInDenylist(any(), any()) } returns false
+            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
         }
     }
 

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
@@ -13,9 +13,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
-import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -47,7 +47,7 @@ internal class SlackDestinationTests {
             )
     }
 
-    @Before
+    @BeforeEach
     fun setup() {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.notifications.core.destinations
 
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -14,9 +13,9 @@ import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
+import org.junit.Before
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -26,7 +25,6 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
-import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
@@ -47,14 +45,13 @@ internal class SlackDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+    }
 
-        @BeforeAll
-        fun setup() {
-            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
-            clearAllMocks()
-            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-            every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
-        }
+    @Before
+    fun setup() {
+        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+        mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.notifications.core.destinations
 
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity
@@ -13,6 +16,7 @@ import org.apache.http.message.BasicStatusLine
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -22,6 +26,7 @@ import org.opensearch.notifications.core.NotificationCoreImpl
 import org.opensearch.notifications.core.client.DestinationHttpClient
 import org.opensearch.notifications.core.transport.DestinationTransportProvider
 import org.opensearch.notifications.core.transport.WebhookDestinationTransport
+import org.opensearch.notifications.core.utils.isHostInDenylist
 import org.opensearch.notifications.spi.model.DestinationMessageResponse
 import org.opensearch.notifications.spi.model.MessageContent
 import org.opensearch.notifications.spi.model.destination.ChimeDestination
@@ -42,6 +47,14 @@ internal class SlackDestinationTests {
                 Arguments.of("\r", """\r"""),
                 Arguments.of("\"", """\""""),
             )
+
+        @BeforeAll
+        fun setup() {
+            // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+            clearAllMocks()
+            mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+            every { isHostInDenylist(any(), any()) } returns false
+        }
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
The Notifications deny list setting (`opensearch.notifications.core.http.host_deny_list`) can take in a list of IPs or IP ranges to be blocked so that messages can't be sent against them. Example:
```
PUT /_cluster/settings
{
  "persistent": {
    "opensearch":{
      "notifications": {
        "core": {
          "http": {
            "host_deny_list": ["127.0.0.1", "10.0.0.0/8"]
          }
        }
      }
    }
  }
}
```

This PR adds hostname resolution before checking against the deny list so that a hostname which is not necessarily an IP (ex. `example.com`) does not bypass the denied IPs.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
