### PR TITLE
Change the SendTestMessage API to be a POST call

### DIFF
--- a/dashboards-notifications/public/services/NotificationService.ts
+++ b/dashboards-notifications/public/services/NotificationService.ts
@@ -246,7 +246,7 @@ export default class NotificationService {
   sendTestMessage = async (
       configId: string
   ) => {
-    const response = await this.httpClient.get(
+    const response = await this.httpClient.post(
         `${NODE_API.SEND_TEST_MESSAGE}/${configId}`
     );
     if (response.status_list[0].delivery_status.status_code != 200) {

--- a/dashboards-notifications/server/clusters/notificationsPlugin.ts
+++ b/dashboards-notifications/server/clusters/notificationsPlugin.ts
@@ -89,7 +89,7 @@ export function NotificationsPlugin(Client: any, config: any, components: any) {
         },
       },
     },
-    method: 'GET',
+    method: 'POST',
   });
 
   notifications.getServerFeatures = clientAction({

--- a/dashboards-notifications/server/routes/eventRoutes.ts
+++ b/dashboards-notifications/server/routes/eventRoutes.ts
@@ -40,7 +40,7 @@ export function eventRoutes(router: IRouter) {
     }
   );
 
-  router.get(
+  router.post(
     {
       path: `${NODE_API.SEND_TEST_MESSAGE}/{configId}`,
       validate: {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
@@ -15,7 +15,7 @@ import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestRequest.Method.GET
+import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestStatus
 
 /**
@@ -43,11 +43,11 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
         return listOf(
             /**
              * Get notification features
-             * Request URL: GET [REQUEST_URL/CONFIG_ID_TAG]
+             * Request URL: POST [REQUEST_URL/CONFIG_ID_TAG]
              * Request body: Ref [org.opensearch.commons.notifications.action.SendNotificationRequest]
              * Response body: [org.opensearch.commons.notifications.action.SendNotificationResponse]
              */
-            Route(GET, "$REQUEST_URL/{$CONFIG_ID_TAG}")
+            Route(POST, "$REQUEST_URL/{$CONFIG_ID_TAG}")
         )
     }
 
@@ -63,7 +63,7 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
      */
     override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         return when (request.method()) {
-            GET -> executeSendTestMessage(request, client)
+            POST -> executeSendTestMessage(request, client)
             else -> RestChannelConsumer {
                 it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
             }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
@@ -13,8 +13,9 @@ import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.notifications.model.SendTestNotificationRequest
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.BytesRestResponse
-import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestStatus
 
@@ -39,15 +40,10 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
+    override fun replacedRoutes(): List<ReplacedRoute> {
         return listOf(
-            /**
-             * Get notification features
-             * Request URL: POST [REQUEST_URL/CONFIG_ID_TAG]
-             * Request body: Ref [org.opensearch.commons.notifications.action.SendNotificationRequest]
-             * Response body: [org.opensearch.commons.notifications.action.SendNotificationResponse]
-             */
-            Route(POST, "$REQUEST_URL/{$CONFIG_ID_TAG}")
+            // Using GET with this API has been deprecated, it will be removed in favor of the POST equivalent in the next major version.
+            ReplacedRoute(POST, "$REQUEST_URL/{$CONFIG_ID_TAG}", GET, "$REQUEST_URL/{$CONFIG_ID_TAG}")
         )
     }
 
@@ -64,6 +60,7 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
     override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         return when (request.method()) {
             POST -> executeSendTestMessage(request, client)
+            GET -> executeSendTestMessage(request, client)
             else -> RestChannelConsumer {
                 it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
             }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/SendTestMessageRestHandler.kt
@@ -42,6 +42,12 @@ internal class SendTestMessageRestHandler : PluginBaseHandler() {
      */
     override fun replacedRoutes(): List<ReplacedRoute> {
         return listOf(
+            /**
+             * Send test notification message
+             * Request URL: POST [REQUEST_URL/CONFIG_ID_TAG]
+             * Request body: Ref [org.opensearch.commons.notifications.action.SendNotificationRequest]
+             * Response body: [org.opensearch.commons.notifications.action.SendNotificationResponse]
+             */
             // Using GET with this API has been deprecated, it will be removed in favor of the POST equivalent in the next major version.
             ReplacedRoute(POST, "$REQUEST_URL/{$CONFIG_ID_TAG}", GET, "$REQUEST_URL/{$CONFIG_ID_TAG}")
         )

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
@@ -42,7 +42,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
 
         // send test message
         val sendResponse = executeRequest(
-            RestRequest.Method.GET.name,
+            RestRequest.Method.POST.name,
             "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
@@ -81,7 +81,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
 
         // send test message
         val sendResponse = executeRequest(
-            RestRequest.Method.GET.name,
+            RestRequest.Method.POST.name,
             "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
@@ -123,7 +123,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
 
         // send test message
         val sendResponse = executeRequest(
-            RestRequest.Method.GET.name,
+            RestRequest.Method.POST.name,
             "$PLUGIN_BASE_URI/feature/test/$configId",
             "",
             RestStatus.INTERNAL_SERVER_ERROR.status
@@ -199,7 +199,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
 
         // send test message
         val sendResponse = executeRequest(
-            RestRequest.Method.GET.name,
+            RestRequest.Method.POST.name,
             "$PLUGIN_BASE_URI/feature/test/$emailConfigId",
             "",
             RestStatus.SERVICE_UNAVAILABLE.status


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
The SendTestMessage API (`/_plugins/_notifications/feature/test`) can potentially invoke POST webhook HTTP calls and from the user's perspective even if it is a test message this can be considered a mutating operation (messages accumulating at some destination that the webhook publishes to). As such, it seems more fitting to change the SendTestMessage API to be a POST call to adhere to HTTP best practices.

The GET API path will still be available until the next major version but will be considered deprecated now. The frontend routes for the Notifications Dashboards plugin will be using the POST method though.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
