### PR TITLE
Disable following redirects for webhooks

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -84,6 +84,7 @@ class DestinationHttpClient {
                 .setConnectionManager(connectionManager)
                 .setRetryHandler(DefaultHttpRequestRetryHandler())
                 .useSystemProperties()
+                .disableRedirectHandling()
                 .build()
         }
     }


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Disabling redirect handling for the HttpClient used when sending Notifications.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
