### PR TITLE
Add bwctestsuite in gradle task

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -413,6 +413,15 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
 }
 
+// A bwc test suite which runs all the bwc tasks combined
+task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    exclude '**/*Test*'
+    exclude '**/*IT*'
+    dependsOn tasks.named("${baseName}#mixedClusterTask")
+    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+}
+
 run {
     doFirst {
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add bwcTestSuite task into the gradle file for run combined bwc Test. 
This functionality is said in the guide but didn't actually get implemented. https://github.com/opensearch-project/notifications/blob/main/DEVELOPER_GUIDE.md#building-from-the-command-line

### Issues Resolved
Part of the https://github.com/opensearch-project/opensearch-build/issues/1873

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
