### PR TITLE
Fix time bounds in query to address indeterminism

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
@@ -543,7 +543,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between initialTime..middleTime
         val getFirstResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${initialTime.toEpochMilli()}..${middleTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${initialTime.toEpochMilli()}..${middleTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )
@@ -553,7 +553,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between middleTime..finalTime
         val getSecondResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${middleTime.toEpochMilli()}..${finalTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${middleTime.toEpochMilli()}..${finalTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )
@@ -563,7 +563,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between finalTime..endTime
         val getThirdResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${finalTime.toEpochMilli()}..${endTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?last_updated_time_ms=${finalTime.toEpochMilli()}..${endTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )
@@ -586,7 +586,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between initialTime..middleTime
         val getFirstResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?created_time_ms=${initialTime.toEpochMilli()}..${middleTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?created_time_ms=${initialTime.toEpochMilli()}..${middleTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )
@@ -596,7 +596,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between middleTime..finalTime
         val getSecondResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?created_time_ms=${middleTime.toEpochMilli()}..${finalTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?created_time_ms=${middleTime.toEpochMilli()}..${finalTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )
@@ -606,7 +606,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         // Get notification configs between finalTime..endTime
         val getThirdResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?created_time_ms=${finalTime.toEpochMilli()}..${endTime.toEpochMilli()}",
+            "$PLUGIN_BASE_URI/configs?created_time_ms=${finalTime.toEpochMilli()}..${endTime.toEpochMilli() - 1}",
             "",
             RestStatus.OK.status
         )


### PR DESCRIPTION
* the millisecond granularity was causing bounds mismatch between 2 intervals
* made the upper bound exclusive while fetching config to fix indeterminism

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
