### PR TITLE
[BUG] Getting DeadlineTimeoutException error during security tests after upgrading to 3.0

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -111,13 +111,19 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
                     // create adminDN (super-admin) client
                     val uri = javaClass.classLoader.getResource("security/sample.pem").toURI()
                     val configPath = PathUtils.get(uri).parent.toAbsolutePath()
-                    SecureRestClientBuilder(settings, configPath).setSocketTimeout(60000).build()
+                    SecureRestClientBuilder(settings, configPath)
+                        .setSocketTimeout(60000)
+                        .setConnectionRequestTimeout(180000)
+                        .build()
                 }
                 false -> {
                     // create client with passed user
                     val userName = System.getProperty("user")
                     val password = System.getProperty("password")
-                    SecureRestClientBuilder(hosts, isHttps(), userName, password).setSocketTimeout(60000).build()
+                    SecureRestClientBuilder(hosts, isHttps(), userName, password)
+                        .setSocketTimeout(60000)
+                        .setConnectionRequestTimeout(180000)
+                        .build()
                 }
             }
         } else {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -35,17 +35,17 @@ class SecurityNotificationIT : PluginRestTestCase() {
 
     @Before
     fun create() {
-
-        if (userClient == null) {
-            createUser(user, user, arrayOf())
-            userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, user).setSocketTimeout(60000).build()
-        }
+        createUser(user, user, arrayOf())
+        userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, user)
+            .setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build()
     }
 
     @After
     fun cleanup() {
-
         userClient?.close()
+        userClient = null
     }
 
     fun `test Create slack notification config with user that has create Notification permission`() {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Getting DeadlineTimeoutException error during security tests after upgrading to 3.0. The test failures were caused by incorrect defaults `SecureRestClientBuilder` related to `connectionRequestTimeout`: the value was set t o`0` which basically meant for strict connection pool to fail immediately if the connection is not available. 

### Issues Resolved
Closes https://github.com/opensearch-project/notifications/issues/580

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
