### PR TITLE
Add index refresh after config creation and deletion in integration tests

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -294,6 +294,22 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         return configId
     }
 
+    fun createConfigWithRequestJsonString(
+        createRequestJsonString: String,
+        client: RestClient = client()
+    ): String {
+        val createResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
+            createRequestJsonString,
+            RestStatus.OK.status,
+            client
+        )
+        refreshAllIndices()
+        Thread.sleep(100)
+        return createResponse.get("config_id").asString
+    }
+
     fun deleteConfig(
         configId: String,
         client: RestClient = client()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -287,6 +287,7 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
             RestStatus.OK.status,
             client
         )
+        refreshAllIndices()
         val configId = createResponse.get("config_id").asString
         Assert.assertNotNull(configId)
         Thread.sleep(100)

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -294,6 +294,36 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         return configId
     }
 
+    fun deleteConfig(
+        configId: String,
+        client: RestClient = client()
+    ): JsonObject {
+        val deleteResponse = executeRequest(
+            RestRequest.Method.DELETE.name,
+            "${NotificationPlugin.PLUGIN_BASE_URI}/configs/$configId",
+            "",
+            RestStatus.OK.status,
+            client
+        )
+        refreshAllIndices()
+        return deleteResponse
+    }
+
+    fun deleteConfigs(
+        configIds: Set<String>,
+        client: RestClient = client()
+    ): JsonObject {
+        val deleteResponse = executeRequest(
+            RestRequest.Method.DELETE.name,
+            "${NotificationPlugin.PLUGIN_BASE_URI}/configs?config_id_list=${configIds.joinToString(separator = ",")}",
+            "",
+            RestStatus.OK.status,
+            client
+        )
+        refreshAllIndices()
+        return deleteResponse
+    }
+
     @After
     open fun wipeAllSettings() {
         wipeAllClusterSettings()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -351,13 +351,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
         Thread.sleep(1000)
 
         // Delete Slack notification config
-        executeRequest(
-            RestRequest.Method.DELETE.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs/$configId",
-            "",
-            RestStatus.OK.status,
-            userClient!!
-        )
+        deleteConfig(configId, userClient!!)
 
         // Should not be able to find config
         executeRequest(

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -74,14 +74,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
         }
         """.trimIndent()
         try {
-            val createResponse = executeRequest(
-                RestRequest.Method.POST.name,
-                "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-                createRequestJsonString,
-                RestStatus.OK.status,
-                userClient!!
-            )
-            val configId = createResponse.get("config_id").asString
+            val configId = createConfigWithRequestJsonString(createRequestJsonString, userClient!!)
             Assert.assertNotNull(configId)
             Thread.sleep(1000)
 
@@ -159,13 +152,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -243,13 +230,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
         }
         """.trimIndent()
 
-        executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.FORBIDDEN.status,
-            userClient!!
-        )
+        createConfigWithRequestJsonString(createRequestJsonString, userClient!!)
         deleteUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE)
     }
 
@@ -278,13 +259,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -340,13 +315,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -471,13 +440,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -515,13 +478,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -230,7 +230,13 @@ class SecurityNotificationIT : PluginRestTestCase() {
         }
         """.trimIndent()
 
-        createConfigWithRequestJsonString(createRequestJsonString, userClient!!)
+        executeRequest(
+            RestRequest.Method.POST.name,
+            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
+            createRequestJsonString,
+            RestStatus.FORBIDDEN.status,
+            userClient!!
+        )
         deleteUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE)
     }
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/bwc/NotificationsBackwardsCompatibilityIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/bwc/NotificationsBackwardsCompatibilityIT.kt
@@ -104,13 +104,7 @@ class NotificationsBackwardsCompatibilityIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "${NotificationPlugin.PLUGIN_BASE_URI}/configs",
-            requestJsonString,
-            RestStatus.OK.status
-        )
-        val createdConfigId = createResponse.get("config_id").asString
+        val createdConfigId = createConfigWithRequestJsonString(requestJsonString)
         assertNotNull(createdConfigId)
         Thread.sleep(100)
     }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -114,12 +114,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete chime notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$configId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -39,13 +39,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -184,13 +178,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -278,13 +266,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/CreateNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/CreateNotificationConfigIT.kt
@@ -44,13 +44,7 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -90,13 +84,8 @@ class CreateNotificationConfigIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        Assert.assertEquals(configId, createResponse.get("config_id").asString)
+        val createdConfigId = createConfigWithRequestJsonString(createRequestJsonString)
+        Assert.assertEquals(configId, createdConfigId)
         Thread.sleep(1000)
 
         // Get chime notification config

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
@@ -12,44 +12,9 @@ import org.opensearch.notifications.verifyMultiConfigIdEquals
 import org.opensearch.notifications.verifySingleConfigIdEquals
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
-import kotlin.random.Random
 
 class DeleteNotificationConfigIT : PluginRestTestCase() {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-
-    private fun getCreateRequestJsonString(): String {
-        val randomString = (1..20)
-            .map { Random.nextInt(0, charPool.size) }
-            .map(charPool::get)
-            .joinToString("")
-        return """
-        {
-            "config_id":"$randomString",
-            "config":{
-                "name":"this is a sample config name $randomString",
-                "description":"this is a sample config description $randomString",
-                "config_type":"slack",
-                "is_enabled":true,
-                "slack":{"url":"https://domain.com/sample_slack_url#$randomString"}
-            }
-        }
-        """.trimIndent()
-    }
-
-//    private fun createConfig(): String {
-//        val createRequestJsonString = getCreateRequestJsonString()
-//        val createResponse = executeRequest(
-//            RestRequest.Method.POST.name,
-//            "$PLUGIN_BASE_URI/configs",
-//            createRequestJsonString,
-//            RestStatus.OK.status
-//        )
-//        refreshAllIndices()
-//        val configId = createResponse.get("config_id").asString
-//        Assert.assertNotNull(configId)
-//        Thread.sleep(100)
-//        return configId
-//    }
 
     fun `test Delete single notification config`() {
         val configId = createConfig()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
@@ -36,19 +36,20 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         """.trimIndent()
     }
 
-    private fun createConfig(): String {
-        val createRequestJsonString = getCreateRequestJsonString()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
-        Assert.assertNotNull(configId)
-        Thread.sleep(100)
-        return configId
-    }
+//    private fun createConfig(): String {
+//        val createRequestJsonString = getCreateRequestJsonString()
+//        val createResponse = executeRequest(
+//            RestRequest.Method.POST.name,
+//            "$PLUGIN_BASE_URI/configs",
+//            createRequestJsonString,
+//            RestStatus.OK.status
+//        )
+//        refreshAllIndices()
+//        val configId = createResponse.get("config_id").asString
+//        Assert.assertNotNull(configId)
+//        Thread.sleep(100)
+//        return configId
+//    }
 
     fun `test Delete single notification config`() {
         val configId = createConfig()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
@@ -31,12 +31,7 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$configId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
         Thread.sleep(100)
 
@@ -88,12 +83,7 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs?config_id_list=${configIds.joinToString(separator = ",")}",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfigs(configIds)
         val deletedObject = deleteResponse.get("delete_response_list").asJsonObject
         configIds.forEach {
             Assert.assertEquals("OK", deletedObject.get(it).asString)
@@ -169,12 +159,7 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         val remainingIds = partitions.second.toSet()
 
         // Delete notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs?config_id_list=${deletedIds.joinToString(separator = ",")}",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfigs(deletedIds)
         val deletedObject = deleteResponse.get("delete_response_list").asJsonObject
         deletedIds.forEach {
             Assert.assertEquals("OK", deletedObject.get(it).asString)

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
@@ -58,13 +58,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(100)
 
@@ -95,13 +89,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailGroupResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailGroupRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailGroupConfigId = createEmailGroupResponse.get("config_id").asString
+        val emailGroupConfigId = createConfigWithRequestJsonString(createEmailGroupRequestJsonString)
         Assert.assertNotNull(emailGroupConfigId)
         Thread.sleep(100)
 
@@ -140,13 +128,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailConfigId = createEmailResponse.get("config_id").asString
+        val emailConfigId = createConfigWithRequestJsonString(createEmailRequestJsonString)
         Assert.assertNotNull(emailConfigId)
         Thread.sleep(1000)
 
@@ -314,13 +296,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSesAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSesAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val sesAccountConfigId = createSesAccountResponse.get("config_id").asString
+        val sesAccountConfigId = createConfigWithRequestJsonString(createSesAccountRequestJsonString)
         Assert.assertNotNull(sesAccountConfigId)
         Thread.sleep(100)
 
@@ -351,13 +327,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailGroupResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailGroupRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailGroupConfigId = createEmailGroupResponse.get("config_id").asString
+        val emailGroupConfigId = createConfigWithRequestJsonString(createEmailGroupRequestJsonString)
         Assert.assertNotNull(emailGroupConfigId)
         Thread.sleep(100)
 
@@ -396,13 +366,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailConfigId = createEmailResponse.get("config_id").asString
+        val emailConfigId = createConfigWithRequestJsonString(createEmailRequestJsonString)
         Assert.assertNotNull(emailConfigId)
         Thread.sleep(1000)
 
@@ -555,13 +519,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(100)
 
@@ -598,13 +556,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailConfigId = createEmailResponse.get("config_id").asString
+        val emailConfigId = createConfigWithRequestJsonString(createEmailRequestJsonString)
         Assert.assertNotNull(emailConfigId)
         Thread.sleep(1000)
 
@@ -704,13 +656,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(100)
 
@@ -784,13 +730,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createEmailGroupResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createEmailGroupRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailGroupConfigId = createEmailGroupResponse.get("config_id").asString
+        val emailGroupConfigId = createConfigWithRequestJsonString(createEmailGroupRequestJsonString)
         Assert.assertNotNull(emailGroupConfigId)
         Thread.sleep(100)
 
@@ -847,13 +787,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(100)
         val createEmailRequestJsonString = """
@@ -908,24 +842,12 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createSmtpAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createSmtpAccountResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(100)
 
         // Create another smtp account
-        val anotherAccountResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createSmtpAccountRequestJsonString,
-            RestStatus.OK.status
-        )
-        val anotherAccountConfigId = anotherAccountResponse.get("config_id").asString
+        val anotherAccountConfigId = createConfigWithRequestJsonString(createSmtpAccountRequestJsonString)
         Assert.assertNotNull(anotherAccountConfigId)
         Thread.sleep(100)
         val createEmailRequestJsonString = """

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
@@ -268,12 +268,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete email notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$emailConfigId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(emailConfigId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(emailConfigId).asString)
         Thread.sleep(1000)
 
@@ -527,12 +522,7 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete email notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$emailConfigId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(emailConfigId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(emailConfigId).asString)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
@@ -18,80 +18,9 @@ import org.opensearch.notifications.verifySingleConfigIdEquals
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
 import java.time.Instant
-import kotlin.random.Random
 
 class QueryNotificationConfigIT : PluginRestTestCase() {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-
-    private fun getCreateRequestJsonString(
-        nameSubstring: String,
-        configType: ConfigType,
-        isEnabled: Boolean
-    ): String {
-        val randomString = (1..20)
-            .map { Random.nextInt(0, charPool.size) }
-            .map(charPool::get)
-            .joinToString("")
-        val configObjectString = when (configType) {
-            ConfigType.SLACK -> """
-                "slack":{"url":"https://slack.domain.com/sample_slack_url#$randomString"}
-            """.trimIndent()
-            ConfigType.CHIME -> """
-                "chime":{"url":"https://chime.domain.com/sample_chime_url#$randomString"}
-            """.trimIndent()
-            ConfigType.WEBHOOK -> """
-                "webhook":{"url":"https://web.domain.com/sample_web_url#$randomString"}
-            """.trimIndent()
-            ConfigType.SMTP_ACCOUNT -> """
-                "smtp_account":{
-                    "host":"smtp.domain.com",
-                    "port":"4321",
-                    "method":"ssl",
-                    "from_address":"$randomString@from.com"
-                }
-            """.trimIndent()
-            ConfigType.EMAIL_GROUP -> """
-                "email_group":{
-                    "recipient_list":[
-                        {"recipient":"$randomString+recipient1@from.com"},
-                        {"recipient":"$randomString+recipient2@from.com"}
-                    ]
-                }
-            """.trimIndent()
-            else -> throw IllegalArgumentException("Unsupported configType=$configType")
-        }
-        return """
-        {
-            "config_id":"$randomString",
-            "config":{
-                "name":"$nameSubstring:this is a sample config name $randomString",
-                "description":"this is a sample config description $randomString",
-                "config_type":"$configType",
-                "is_enabled":$isEnabled,
-                $configObjectString
-            }
-        }
-        """.trimIndent()
-    }
-
-//    private fun createConfig(
-//        nameSubstring: String = "",
-//        configType: ConfigType = ConfigType.SLACK,
-//        isEnabled: Boolean = true
-//    ): String {
-//        val createRequestJsonString = getCreateRequestJsonString(nameSubstring, configType, isEnabled)
-//        val createResponse = executeRequest(
-//            RestRequest.Method.POST.name,
-//            "$PLUGIN_BASE_URI/configs",
-//            createRequestJsonString,
-//            RestStatus.OK.status
-//        )
-//        refreshAllIndices()
-//        val configId = createResponse.get("config_id").asString
-//        Assert.assertNotNull(configId)
-//        Thread.sleep(100)
-//        return configId
-//    }
 
     fun `test Get single notification config as part of path`() {
         val configId = createConfig()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
@@ -74,23 +74,24 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         """.trimIndent()
     }
 
-    private fun createConfig(
-        nameSubstring: String = "",
-        configType: ConfigType = ConfigType.SLACK,
-        isEnabled: Boolean = true
-    ): String {
-        val createRequestJsonString = getCreateRequestJsonString(nameSubstring, configType, isEnabled)
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
-        Assert.assertNotNull(configId)
-        Thread.sleep(100)
-        return configId
-    }
+//    private fun createConfig(
+//        nameSubstring: String = "",
+//        configType: ConfigType = ConfigType.SLACK,
+//        isEnabled: Boolean = true
+//    ): String {
+//        val createRequestJsonString = getCreateRequestJsonString(nameSubstring, configType, isEnabled)
+//        val createResponse = executeRequest(
+//            RestRequest.Method.POST.name,
+//            "$PLUGIN_BASE_URI/configs",
+//            createRequestJsonString,
+//            RestStatus.OK.status
+//        )
+//        refreshAllIndices()
+//        val configId = createResponse.get("config_id").asString
+//        Assert.assertNotNull(configId)
+//        Thread.sleep(100)
+//        return configId
+//    }
 
     fun `test Get single notification config as part of path`() {
         val configId = createConfig()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
@@ -787,13 +787,8 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        Assert.assertEquals(absentId, createResponse.get("config_id").asString)
+        val createdConfigId = createConfigWithRequestJsonString(createRequestJsonString)
+        Assert.assertEquals(absentId, createdConfigId)
         Thread.sleep(1000)
 
         // Get chime notification config

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
@@ -115,12 +115,7 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete slack notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$configId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SlackNotificationConfigCrudIT.kt
@@ -40,13 +40,7 @@ class SlackNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
@@ -115,12 +115,7 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete SNS notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$configId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/SnsNotificationConfigCrudIT.kt
@@ -40,13 +40,7 @@ class SnsNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
@@ -131,12 +131,7 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         // Delete webhook notification config
-        val deleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$PLUGIN_BASE_URI/configs/$configId",
-            "",
-            RestStatus.OK.status
-        )
+        val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/WebhookNotificationConfigCrudIT.kt
@@ -48,13 +48,7 @@ class WebhookNotificationConfigCrudIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/send/SendTestMessageRestHandlerIT.kt
@@ -30,13 +30,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -69,13 +63,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -111,13 +99,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            createRequestJsonString,
-            RestStatus.OK.status
-        )
-        val configId = createResponse.get("config_id").asString
+        val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
         Thread.sleep(1000)
 
@@ -159,13 +141,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
             }
         }
         """.trimIndent()
-        val createResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            smtpAccountCreateRequestJsonString,
-            RestStatus.OK.status
-        )
-        val smtpAccountConfigId = createResponse.get("config_id").asString
+        val smtpAccountConfigId = createConfigWithRequestJsonString(smtpAccountCreateRequestJsonString)
         Assert.assertNotNull(smtpAccountConfigId)
         Thread.sleep(1000)
 
@@ -187,13 +163,7 @@ internal class SendTestMessageRestHandlerIT : PluginRestTestCase() {
         }
         """.trimIndent()
 
-        val emailCreateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$PLUGIN_BASE_URI/configs",
-            emailCreateRequestJsonString,
-            RestStatus.OK.status
-        )
-        val emailConfigId = emailCreateResponse.get("config_id").asString
+        val emailConfigId = createConfigWithRequestJsonString(emailCreateRequestJsonString)
         Assert.assertNotNull(emailConfigId)
         Thread.sleep(1000)
 


### PR DESCRIPTION
### Description
Refactor the calls to Notification config creation and deletion in the integration tests by using helper methods that contain calls to refresh all indices after the config create/delete calls. This is to ensure that the searchable state of the Notification config index is as expected so the assertion calls pass (to avoid flaky failures).

When https://github.com/opensearch-project/notifications/issues/381 is added, these helper methods can be updated to have the refresh policy within the REST call itself. The refactoring of the tests makes it easier to make that change later on.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
