### PR TITLE
Revert "Remove Jackson databind and annotations (#591)"

### DIFF
--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -83,6 +83,8 @@ configurations.all {
         force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-annotations:2.11.4" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-databind:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4" // resolve for amazonaws

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -108,6 +108,8 @@ configurations.all {
         force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}" // resolve for amazonaws
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}" // resolve for amazonaws
+        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.11.4" // resolve for amazonaws
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4" // resolve for amazonaws
@@ -124,6 +126,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sts:${aws_version}"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -94,6 +94,8 @@ dependencies {
     compileOnly "com.github.wnameless.json:json-flattener:0.13.0"
     // TODO: uncomment when the _local/stats API is supported
     // implementation "com.github.wnameless.json:json-base:2.0.0"
+    // implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    // implementation "com.fasterxml.jackson.core:jackson-annotations:2.10.4"
 
 
     testImplementation(


### PR DESCRIPTION
This reverts commit f39bf04d4ba99b08715fd72ddc6b9390b33f9764.

### Description
Jackson is no longer in core, so reverting changes made for https://github.com/opensearch-project/notifications/issues/579

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
