### PR TITLE
fix workflow failure on Cypress cache

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ matrix.cypress_cache_folder }}
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('OpenSearch-Dashboards/plugins/dashboards-notifications/package.json') }}
 
       - name: Reset npm's script shell
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
Signed-off-by: Chenyang Ji <cyji@amazon.com>

### Description
The Windows workflow for the `notifications` plugin has been constantly failing on the same error:
```
Error: .github/workflows/dashboards-notifications-test-and-build-workflow.yml (Line: 171, Col: 16):
Error: The template is not valid. .github/workflows/dashboards-notifications-test-and-build-workflow.yml (Line: 171, Col: 16): hashFiles('**/package.json') couldn't finish within [120](https://github.com/opensearch-project/dashboards-notifications/actions/runs/3879144103/jobs/6616037715#step:19:2) seconds.
```
Some examples: 
https://github.com/opensearch-project/notifications/actions/runs/3858703629/jobs/6577511119
https://github.com/opensearch-project/notifications/actions/runs/3851206488/jobs/6562149762

After some research and testing, I think this is caused by the `hashFiles` expression not able to handle requested files if there are huge amount of files in the working directory (`GITHUB_WORKSPACE`).

Explicitly specifying the hashed file as the `package.json` of repo can fix the build failure.

References:
https://docs.github.com/en/actions/learn-github-actions/expressions
https://github.com/actions/runner/issues/1840
https://github.com/actions/runner/issues/449


### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
