### PR TITLE
Feature send notification via telegram #584

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/DestinationType.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/DestinationType.kt
@@ -8,5 +8,5 @@ package org.opensearch.notifications.spi.model.destination
  * Supported notification destinations
  */
 enum class DestinationType {
-    CHIME, SLACK, CUSTOM_WEBHOOK, SMTP, SES, SNS
+    CHIME, SLACK, CUSTOM_WEBHOOK, SMTP, SES, SNS, TELEGRAM
 }

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/TelegramDestination.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/TelegramDestination.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.spi.model.destination
+/*
+This class holds the contents of a Telegram  destination
+ */
+class TelegramDestination(
+    val token: String,
+    val chatId: Long,
+    val url: String = "https://api.telegram.org/bot$token/sendMessage?chat_id=$chatId"
+) : WebhookDestination(url, DestinationType.TELEGRAM)

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/TelegramDestination.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/TelegramDestination.kt
@@ -8,7 +8,5 @@ package org.opensearch.notifications.spi.model.destination
 This class holds the contents of a Telegram  destination
  */
 class TelegramDestination(
-    val token: String,
-    val chatId: Long,
-    val url: String = "https://api.telegram.org/bot$token/sendMessage?chat_id=$chatId"
+    url: String
 ) : WebhookDestination(url, DestinationType.TELEGRAM)

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpers.kt
@@ -90,3 +90,21 @@ fun validateMethod(method: String) {
         method.findAnyOf(validMethods) != null
     ) { "Invalid method supplied. Only POST, PUT and PATCH are allowed" }
 }
+private fun validateTelegramToken(token: String) {
+    val url = URL("https://api.telegram.org/bot$token/getMe")
+    val connection = url.openConnection() as HttpURLConnection
+
+    connection.requestMethod = "GET"
+    val response = connection.responseCode
+    if (response != 200) {
+        throw IllegalArgumentException("Invalid Telegram token")
+    }
+    val responseBuilder = StringBuilder()
+    val input = BufferedReader(InputStreamReader(connection.inputStream))
+    var inputLine: String? = input.readLine()
+    while (inputLine != null) {
+        responseBuilder.append(inputLine)
+        inputLine = input.readLine()
+    }
+    input.close()
+}

--- a/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
+++ b/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
@@ -22,6 +22,7 @@ internal class ValidationHelpersTests {
     private val LOCAL_HOST_EXTENDED = "https://localhost:6060/service"
     private val WEBHOOK_URL = "https://test-webhook.com:1234/subdirectory?param1=value1&param2=&param3=value3"
     private val CHIME_URL = "https://domain.com/sample_chime_url#1234567890"
+    private val TELEGRAM_URL ="https://api.telegram.org/bot{token}/sendMessage?chat_id={chatId}"
 
     private val hostDenyList = listOf(
         "127.0.0.0/8",
@@ -99,4 +100,9 @@ internal class ValidationHelpersTests {
     fun `validator identifies chime url as valid`() {
         assert(isValidUrl(CHIME_URL))
     }
+    @Test
+    fun `validator identifies webhook url as valid`() {
+        assert(isValidUrl(TELEGRAM_URL))
+    }
+
 }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/transport/DestinationTransportProvider.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/transport/DestinationTransportProvider.kt
@@ -28,6 +28,7 @@ internal object DestinationTransportProvider {
         DestinationType.SMTP to smtpDestinationTransport,
         DestinationType.SNS to snsDestinationTransport,
         DestinationType.SES to sesDestinationTransport
+        DestinationType.TELEGRAM to webhookDestinationTransport,
     )
 
     /**

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/TelegramDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/TelegramDestinationTests.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.core.destinations
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.apache.hc.client5.http.classic.methods.HttpPost
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.easymock.EasyMock
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.opensearch.notifications.core.NotificationCoreImpl
+import org.opensearch.notifications.core.client.DestinationHttpClient
+import org.opensearch.notifications.core.transport.DestinationTransportProvider
+import org.opensearch.notifications.core.transport.WebhookDestinationTransport
+import org.opensearch.notifications.spi.model.DestinationMessageResponse
+import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.TelegramDestination
+import org.opensearch.notifications.spi.model.destination.DestinationType
+import org.opensearch.rest.RestStatus
+import java.net.MalformedURLException
+import java.util.stream.Stream
+
+internal class TelegramDestinationTests {
+    companion object {
+        @JvmStatic
+        fun escapeSequenceToRaw(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("\n", """\n"""),
+                Arguments.of("\t", """\t"""),
+                Arguments.of("\b", """\b"""),
+                Arguments.of("\r", """\r"""),
+                Arguments.of("\"", """\""""),
+            )
+    }
+
+    @BeforeEach
+    fun setup() {
+        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+        mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
+        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
+    }
+
+    @Test
+    fun `test telegram message null entity response`() {
+        val mockHttpClient = mockk<CloseableHttpClient>()
+
+        // The DestinationHttpClient replaces a null entity with "{}".
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
+        // TODO replace EasyMock in all UTs with mockk which fits Kotlin better
+        val httpResponse = mockk<CloseableHttpResponse>()
+        every { mockHttpClient.execute(any<HttpPost>()) } returns httpResponse
+
+        every { httpResponse.code } returns RestStatus.OK.status
+        every { httpResponse.entity } returns null
+
+        val httpClient = DestinationHttpClient(mockHttpClient)
+        val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.TELEGRAM to webhookDestinationTransport)
+
+        val title = "test Telegram"
+        val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member call out: " +
+                "@All All Present member call out: @Present"
+        val url = "https://abc/com"
+
+        val destination = TelegramDestination(url)
+        val message = MessageContent(title, messageText)
+
+        val actualTelelegramResponsee: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+
+        assertEquals(expectedWebhookResponse.statusText, actualTelelegramResponse.statusText)
+        assertEquals(expectedWebhookResponse.statusCode, actualTelelegramResponse.statusCode)
+    }
+
+    @Test
+    fun `test chime message empty entity response`() {
+        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "")
+
+        val httpResponse = mockk<CloseableHttpResponse>()
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        every { httpResponse.code } returns RestStatus.OK.status
+        every { httpResponse.entity } returns StringEntity("")
+        EasyMock.replay(mockHttpClient)
+
+        val httpClient = DestinationHttpClient(mockHttpClient)
+        val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.TELEGRAM to webhookDestinationTransport)
+
+        val title = "test Telegram"
+        val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member call out: " +
+                "@All All Present member call out: @Present\"}"
+        val url = "https://abc/com"
+
+        val destination = TelegramDestination(url)
+        val message = MessageContent(title, messageText)
+
+        val actualTelegramResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+
+        assertEquals(expectedWebhookResponse.statusText, actualTelegramResponse.statusText)
+        assertEquals(expectedWebhookResponse.statusCode, actualTelegramResponse.statusCode)
+    }
+
+    @Test
+    fun `test telegram message non-empty entity response`() {
+        val responseContent = "It worked!"
+        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
+        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
+
+        val httpResponse = mockk<CloseableHttpResponse>()
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        every { httpResponse.code } returns RestStatus.OK.status
+        every { httpResponse.entity } returns StringEntity(responseContent)
+        EasyMock.replay(mockHttpClient)
+
+        val httpClient = DestinationHttpClient(mockHttpClient)
+        val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.TELEGRAM to webhookDestinationTransport)
+
+        val title = "test Telegram"
+        val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member call out: " +
+                "@All All Present member call out: @Present\"}"
+        val url = "https://abc/com"
+
+        val destination = TelegramDestination(url)
+        val message = MessageContent(title, messageText)
+
+        val actualTelelegramResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+
+        assertEquals(expectedWebhookResponse.statusText, actualTelelegramResponse.statusText)
+        assertEquals(expectedWebhookResponse.statusCode, actualTelelegramResponse.statusCode)
+    }
+
+    @Test
+    fun `test url missing should throw IllegalArgumentException with message`() {
+        val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            TelegramDestination("")
+        }
+        assertEquals("url is null or empty", exception.message)
+    }
+
+    @Test
+    fun testUrlInvalidMessage() {
+        assertThrows<MalformedURLException> {
+            TelegramDestination("invalidUrl")
+        }
+    }
+
+    @Test
+    fun `test content missing content should throw IllegalArgumentException`() {
+        val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            MessageContent("title", "")
+        }
+        assertEquals("text message part is null or empty", exception.message)
+    }
+
+    @ParameterizedTest
+    @MethodSource("escapeSequenceToRaw")
+    fun `test build request body for telegram webhook should have title included and prevent escape`(
+        escapeSequence: String,
+        rawString: String
+    ) {
+        val httpClient = DestinationHttpClient()
+        val title = "test telegram webhook"
+        val messageText = "line1${escapeSequence}line2"
+        val url = "https://abc/com"
+        val expectedRequestBody = """{"Content":"$title\n\nline1${rawString}line2"}"""
+        val destination = TelegramDestination(url)
+        val message = MessageContent(title, messageText)
+        val actualRequestBody = httpClient.buildRequestBody(destination, message)
+        assertEquals(expectedRequestBody, actualRequestBody)
+    }
+}


### PR DESCRIPTION
### Description
Adds  a class of telegram destination 

### Issues Resolved
It  support a new channel and custom webhook to select message 


### Check List
- [ X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
