### PR TITLE
Publish snapshots to maven via GHA

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,11 +13,8 @@ jobs:
   build-and-publish-snapshots:
     strategy:
       fail-fast: false
-      matrix:
-        jdk: [17]
-        platform: ["ubuntu-latest"]
     if: github.repository == 'opensearch-project/notifications'
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write
@@ -27,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: ${{ matrix.jdk }}
+          java-version: 17
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         jdk: [11, 17]
         platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
-    if: github.repository == 'opensearch-project/security'
+    if: github.repository == 'opensearch-project/notifications'
     runs-on: ${{ matrix.platform }}
 
     permissions:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        jdk: [17]
+        platform: ["ubuntu-latest"]
     if: github.repository == 'opensearch-project/notifications'
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,43 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+      branches: [
+        main
+        1.*
+        2.*
+      ]
+
+jobs:
+  build-and-publish-snapshots:
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    if: github.repository == 'opensearch-project/security'
+    runs-on: ${{ matrix.platform }}
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.jdk }}
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository
+

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -126,17 +126,6 @@ publishing {
         }
     }
 
-    repositories {
-        maven {
-            name = "Snapshots"
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-            credentials {
-                username "$System.env.SONATYPE_USERNAME"
-                password "$System.env.SONATYPE_PASSWORD"
-            }
-        }
-    }
-
     gradle.startParameter.setShowStacktrace(ShowStacktrace.ALWAYS)
     gradle.startParameter.setLogLevel(LogLevel.DEBUG)
 

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -126,6 +126,17 @@ publishing {
         }
     }
 
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
+
     gradle.startParameter.setShowStacktrace(ShowStacktrace.ALWAYS)
     gradle.startParameter.setLogLevel(LogLevel.DEBUG)
 

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -61,6 +61,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
 
 task integTest(type: RestIntegTestTask) {

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -57,6 +57,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
 
 allOpen {


### PR DESCRIPTION
### Description
Publish snapshots to maven via GHA

### Issues Resolved
#620

### Testing:
```
find notifications/snapshots | sort
notifications/snapshots
notifications/snapshots/org
notifications/snapshots/org/opensearch
notifications/snapshots/org/opensearch/plugin
notifications/snapshots/org/opensearch/plugin/notifications
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/maven-metadata.xml
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/maven-metadata.xml.md5
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha1
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha256
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha512
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.pom
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.pom.md5
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.pom.sha1
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.pom.sha256
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.pom.sha512
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.zip
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.zip.md5
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.zip.sha1
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.zip.sha256
notifications/snapshots/org/opensearch/plugin/notifications/3.0.0.0-SNAPSHOT/notifications-3.0.0.0-20230221.175731-1.zip.sha512
notifications/snapshots/org/opensearch/plugin/notifications/maven-metadata.xml
notifications/snapshots/org/opensearch/plugin/notifications/maven-metadata.xml.md5
notifications/snapshots/org/opensearch/plugin/notifications/maven-metadata.xml.sha1
notifications/snapshots/org/opensearch/plugin/notifications/maven-metadata.xml.sha256
notifications/snapshots/org/opensearch/plugin/notifications/maven-metadata.xml.sha512
```

```
find core/snapshots | sort
core/snapshots
core/snapshots/org
core/snapshots/org/opensearch
core/snapshots/org/opensearch/plugin
core/snapshots/org/opensearch/plugin/opensearch-notifications-core
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/maven-metadata.xml
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/maven-metadata.xml.md5
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha1
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha256
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/maven-metadata.xml.sha512
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.pom
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.pom.md5
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.pom.sha1
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.pom.sha256
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.pom.sha512
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.zip
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.zip.md5
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.zip.sha1
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.zip.sha256
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/3.0.0.0-SNAPSHOT/opensearch-notifications-core-3.0.0.0-20230221.175731-1.zip.sha512
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/maven-metadata.xml
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/maven-metadata.xml.md5
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/maven-metadata.xml.sha1
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/maven-metadata.xml.sha256
core/snapshots/org/opensearch/plugin/opensearch-notifications-core/maven-metadata.xml.sha512
```

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
