### PR TITLE
fix for notifications gha workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-		  cd notifications/
+          cd notifications/
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,5 +36,6 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
+		  cd notifications/
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
 


### PR DESCRIPTION
### Description
this pr switches the workflow to execute in the `notifications` root dir.

### Issues Resolved
Failed snapshot builds:
https://github.com/opensearch-project/notifications/actions/runs/4238510591/jobs/7365660955
https://github.com/opensearch-project/notifications/actions/runs/4238504523

Passed builds:
https://github.com/opensearch-project/notifications/actions/runs/4238881744/jobs/7366406360

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
