### PR TITLE
Fixed build failure due to OSCore xcontent changes

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
@@ -11,7 +11,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.io.stream.NamedWriteableRegistry
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
 import org.opensearch.notifications.core.setting.PluginSettings

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/Helpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/Helpers.kt
@@ -8,7 +8,7 @@ package org.opensearch.notifications.core.utils
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.opensearch.common.bytes.BytesReference
-import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentBuilder
 
 fun <T : Any> logger(forClass: Class<T>): Lazy<Logger> {
     return lazy { LogManager.getLogger(forClass) }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -17,9 +17,9 @@ import org.opensearch.common.settings.IndexScopedSettings
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.settings.SettingsFilter
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
 import org.opensearch.notifications.action.CreateNotificationConfigAction
@@ -164,7 +164,7 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension {
             NotificationConfigRestHandler(),
             NotificationFeaturesRestHandler(),
             NotificationChannelListRestHandler(),
-            SendTestMessageRestHandler(),
+            SendTestMessageRestHandler()
             // NotificationStatsRestHandler()
         )
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/CreateNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/CreateNotificationConfigAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/DeleteNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/DeleteNotificationConfigAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetChannelListAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetChannelListAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.GetChannelListRequest
 import org.opensearch.commons.notifications.action.GetChannelListResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetNotificationConfigAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
 import org.opensearch.commons.notifications.action.GetNotificationConfigResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/GetPluginFeaturesAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.GetPluginFeaturesRequest
 import org.opensearch.commons.notifications.action.GetPluginFeaturesResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.CoreProvider
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PublishNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PublishNotificationAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequest
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.send.SendMessageActionHelper
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendNotificationAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.notifications.action.SendNotificationRequest
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.send.SendMessageActionHelper
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendTestNotificationAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/SendTestNotificationAction.kt
@@ -12,10 +12,10 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.client.Client
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.notifications.NotificationsPluginInterface
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
 import org.opensearch.notifications.model.SendTestNotificationRequest
 import org.opensearch.notifications.send.SendTestNotificationActionHelper
@@ -29,7 +29,7 @@ internal class SendTestNotificationAction @Inject constructor(
     transportService: TransportService,
     val client: Client,
     actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry,
+    val xContentRegistry: NamedXContentRegistry
 ) : HandledTransportAction<SendTestNotificationRequest, SendNotificationResponse>(
     NAME,
     transportService,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/UpdateNotificationConfigAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/UpdateNotificationConfigAction.kt
@@ -10,12 +10,12 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.common.inject.Inject
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.NotificationsActions
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
 import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigQueryHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigQueryHelper.kt
@@ -93,11 +93,11 @@ object ConfigQueryHelper {
     private val NESTED_KEYWORD_FIELDS = setOf(
         // Text fields with keyword
         "${EMAIL.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG.$KEYWORD_SUFFIX",
-        "${EMAIL_GROUP.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG.$KEYWORD_SUFFIX",
+        "${EMAIL_GROUP.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG.$KEYWORD_SUFFIX"
     )
     private val NESTED_TEXT_FIELDS = setOf(
         "${EMAIL.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG",
-        "${EMAIL_GROUP.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG",
+        "${EMAIL_GROUP.tag}.$RECIPIENT_LIST_TAG.$RECIPIENT_TAG"
     )
 
     private val METADATA_FIELDS = METADATA_RANGE_FIELDS

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -26,7 +26,6 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
@@ -34,6 +33,7 @@ import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.NotificationConfigSearchResult
 import org.opensearch.commons.notifications.model.SearchResults
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
@@ -34,7 +34,8 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         RollingCounter()
     ),
     NOTIFICATIONS_EXCEPTIONS_VERSION_CONFLICT_ENGINE_EXCEPTION(
-        "exception.version_conflict_engine", RollingCounter()
+        "exception.version_conflict_engine",
+        RollingCounter()
     ),
     NOTIFICATIONS_EXCEPTIONS_INDEX_NOT_FOUND_EXCEPTION(
         "exception.index_not_found",
@@ -84,20 +85,24 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_UPDATE_USER_ERROR_INVALID_CONFIG_ID(
-        "notifications_config.update.user_error.invalid_config_id", RollingCounter()
+        "notifications_config.update.user_error.invalid_config_id",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_UPDATE_SYSTEM_ERROR(
         "notifications_config.update.system_error",
         RollingCounter()
     ), // Notification config general user error
     NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_ACCOUNT_ID(
-        "notifications_config.user_error.invalid_email_account_id", RollingCounter()
+        "notifications_config.user_error.invalid_email_account_id",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_GROUP_ID(
-        "notifications_config.user_error.invalid_email_group_id", RollingCounter()
+        "notifications_config.user_error.invalid_email_group_id",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_USER_ERROR_NEITHER_EMAIL_NOR_GROUP(
-        "notifications_config.user_error.neither_email_nor_group", RollingCounter()
+        "notifications_config.user_error.neither_email_nor_group",
+        RollingCounter()
     ), // DELETE _plugins/_notifications/configs/{configId}, Delete a notification config
     NOTIFICATIONS_CONFIG_DELETE_TOTAL(
         "notifications_config.delete.total",
@@ -108,10 +113,12 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_DELETE_USER_ERROR_INVALID_CONFIG_ID(
-        "notifications_config.delete.user_error.invalid_config_id", RollingCounter()
+        "notifications_config.delete.user_error.invalid_config_id",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_DELETE_USER_ERROR_SET_NOT_FOUND(
-        "notifications_config.delete.user_error.set_not_found", RollingCounter()
+        "notifications_config.delete.user_error.set_not_found",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_DELETE_SYSTEM_ERROR(
         "notifications_config.delete.system_error",
@@ -126,11 +133,14 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         RollingCounter()
     ), // add specific user errors for config GET operations
     NOTIFICATIONS_CONFIG_INFO_USER_ERROR_INVALID_CONFIG_ID(
-        "notifications_config.info.user_error.invalid_config_id", RollingCounter()
+        "notifications_config.info.user_error.invalid_config_id",
+        RollingCounter()
     ),
     NOTIFICATIONS_CONFIG_INFO_USER_ERROR_SET_NOT_FOUND(
-        "notifications_config.info.user_error.set_not_found", RollingCounter()
+        "notifications_config.info.user_error.set_not_found",
+        RollingCounter()
     ),
+
     // Feature Channels Endpoints
     // GET _plugins/_notifications/channels
     NOTIFICATIONS_CHANNELS_INFO_TOTAL(
@@ -138,8 +148,10 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         BasicCounter()
     ),
     NOTIFICATIONS_CHANNELS_INFO_INTERVAL_COUNT(
-        "notifications_channels.info.count", RollingCounter()
+        "notifications_channels.info.count",
+        RollingCounter()
     ),
+
     // Features Endpoints
     // GET _plugins/_notifications/features
     NOTIFICATIONS_FEATURES_INFO_TOTAL(
@@ -150,6 +162,7 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         "notifications_features.info.count",
         RollingCounter()
     ),
+
     // Send Message Endpoints
     // POST _plugins/_notifications/send
     NOTIFICATIONS_SEND_MESSAGE_TOTAL(
@@ -161,7 +174,8 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         RollingCounter()
     ), // user errors for send message?
     NOTIFICATIONS_SEND_MESSAGE_USER_ERROR_NOT_FOUND(
-        "notifications.send_message.user_error.not_found", RollingCounter()
+        "notifications.send_message.user_error.not_found",
+        RollingCounter()
     ),
     NOTIFICATIONS_MESSAGE_DESTINATION_SLACK(
         "notifications.message_destination.slack",
@@ -180,18 +194,22 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         BasicCounter()
     ),
     NOTIFICATIONS_MESSAGE_DESTINATION_SES_ACCOUNT(
-        "notifications.message_destination.ses_account", BasicCounter()
+        "notifications.message_destination.ses_account",
+        BasicCounter()
     ),
     NOTIFICATIONS_MESSAGE_DESTINATION_SMTP_ACCOUNT(
-        "notifications.message_destination.smtp_account", BasicCounter()
+        "notifications.message_destination.smtp_account",
+        BasicCounter()
     ),
     NOTIFICATIONS_MESSAGE_DESTINATION_EMAIL_GROUP(
-        "notifications.message_destination.email_group", BasicCounter()
+        "notifications.message_destination.email_group",
+        BasicCounter()
     ), // TODO: add after implementation added
     NOTIFICATIONS_MESSAGE_DESTINATION_SNS(
         "notifications.message_destination.sns",
         BasicCounter()
     ),
+
     // Send Test Message Endpoints
     // GET _plugins/_notifications/feature/test/{configId}
     NOTIFICATIONS_SEND_TEST_MESSAGE_TOTAL(
@@ -199,7 +217,8 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
         BasicCounter()
     ),
     NOTIFICATIONS_SEND_TEST_MESSAGE_INTERVAL_COUNT(
-        "notifications.send_test_message.interval_count", RollingCounter()
+        "notifications.send_test_message.interval_count",
+        RollingCounter()
     ), // Send test message exceptions are thrown by the Send Message Action
     NOTIFICATIONS_SECURITY_USER_ERROR(
         "security_user_error",

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/DocMetadata.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/DocMetadata.kt
@@ -5,14 +5,14 @@
 
 package org.opensearch.notifications.model
 
-import org.opensearch.common.xcontent.ToXContent
-import org.opensearch.common.xcontent.XContentBuilder
-import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.notifications.NotificationConstants.CREATED_TIME_TAG
 import org.opensearch.commons.notifications.NotificationConstants.UPDATED_TIME_TAG
 import org.opensearch.commons.utils.logger
 import org.opensearch.commons.utils.stringList
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
 import java.time.Instant
 
 /**

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/NotificationConfigDoc.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/NotificationConfigDoc.kt
@@ -4,14 +4,14 @@
  */
 package org.opensearch.notifications.model
 
-import org.opensearch.common.xcontent.ToXContent
-import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory
-import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.notifications.NotificationConstants.CONFIG_TAG
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.notifications.model.DocMetadata.Companion.METADATA_TAG
 import java.io.IOException
 

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/SendTestNotificationRequest.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/model/SendTestNotificationRequest.kt
@@ -11,13 +11,13 @@ import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
-import org.opensearch.common.xcontent.ToXContent
-import org.opensearch.common.xcontent.ToXContentObject
-import org.opensearch.common.xcontent.XContentBuilder
-import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.notifications.NotificationConstants.CONFIG_ID_TAG
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
 import java.io.IOException
 
 /**
@@ -69,7 +69,7 @@ class SendTestNotificationRequest : ActionRequest, ToXContentObject {
      * @param configId the id of the notification configuration channel
      */
     constructor(
-        configId: String,
+        configId: String
     ) {
         this.configId = configId
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/RestResponseToXContentListener.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/resthandler/RestResponseToXContentListener.kt
@@ -5,8 +5,8 @@
 
 package org.opensearch.notifications.resthandler
 
-import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.commons.notifications.action.BaseResponse
+import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
@@ -35,6 +35,7 @@ internal class RestResponseToXContentListener<Response : BaseResponse>(channel: 
         }
         return BytesRestResponse(getStatus(response), builder)
     }
+
     /**
      * {@inheritDoc}
      */

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.destination.message.LegacyBaseMessage
@@ -37,6 +36,7 @@ import org.opensearch.commons.notifications.model.SmtpAccount
 import org.opensearch.commons.notifications.model.Sns
 import org.opensearch.commons.notifications.model.Webhook
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.notifications.CoreProvider
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
 import org.opensearch.notifications.index.ConfigOperations
@@ -97,7 +97,8 @@ object SendMessageActionHelper {
         if (overallStatusCode != RestStatus.OK.status.toString()) {
             val errorMessage = "{\"event_status_list\": $eventStatusListString}"
             throw OpenSearchStatusException(
-                errorMessage, RestStatus.fromCode(overallStatusCode!!.toInt())
+                errorMessage,
+                RestStatus.fromCode(overallStatusCode!!.toInt())
             )
         }
 
@@ -131,7 +132,7 @@ object SendMessageActionHelper {
             channelMessage.attachment?.fileName,
             channelMessage.attachment?.fileEncoding,
             channelMessage.attachment?.fileData,
-            channelMessage.attachment?.fileContentType,
+            channelMessage.attachment?.fileContentType
         )
     }
 

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -123,32 +123,38 @@ internal object PluginSettings {
         OPERATION_TIMEOUT_MS_KEY,
         defaultSettings[OPERATION_TIMEOUT_MS_KEY]!!.toLong(),
         MINIMUM_OPERATION_TIMEOUT_MS,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     val DEFAULT_ITEMS_QUERY_COUNT: Setting<Int> = Setting.intSetting(
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     val LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
         LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES_KEY,
         false,
-        NodeScope, Dynamic, Deprecated,
+        NodeScope,
+        Dynamic,
+        Deprecated
     )
 
     val ALERTING_FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
         ALERTING_FILTER_BY_BACKEND_ROLES_KEY,
         LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
         FILTER_BY_BACKEND_ROLES_KEY,
         ALERTING_FILTER_BY_BACKEND_ROLES,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     fun isRbacEnabled(): Boolean {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/IntegTestHelpers.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/IntegTestHelpers.kt
@@ -176,8 +176,12 @@ class NotificationsJsonEntity(
     var jsonEntityString: String = ""
 
     private constructor(builder: Builder) : this(
-        builder.refTag, builder.recipients, builder.title,
-        builder.textDescription, builder.htmlDescription, builder.attachment
+        builder.refTag,
+        builder.recipients,
+        builder.title,
+        builder.textDescription,
+        builder.htmlDescription,
+        builder.attachment
     )
 
     fun getJsonEntityAsString(): String {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -17,12 +17,12 @@ import org.opensearch.client.RestClient
 import org.opensearch.client.WarningsHandler
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.DeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.rest.SecureRestClientBuilder
+import org.opensearch.core.xcontent.DeprecationHandler
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.NotificationPlugin
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
@@ -69,7 +69,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
         val xContentType = XContentType.fromMediaType(response.entity.contentType)
         xContentType.xContent().createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
             response.entity.content
         ).use { parser ->
             for (index in parser.list()) {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -24,7 +24,8 @@ class SecurityNotificationIT : PluginRestTestCase() {
 
     companion object {
         @BeforeClass
-        @JvmStatic fun setup() {
+        @JvmStatic
+        fun setup() {
             // things to execute once and keep around for the class
             org.junit.Assume.assumeTrue(System.getProperty("https", "false")!!.toBoolean())
         }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/EmailNotificationConfigCrudIT.kt
@@ -715,7 +715,6 @@ class EmailNotificationConfigCrudIT : PluginRestTestCase() {
     }
 
     fun `test Create email notification config wit email_group IDs put as email account id should fail`() {
-
         // Create email group notification config
         val createEmailGroupRequestJsonString = """
         {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/TestHelpers.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/TestHelpers.kt
@@ -5,12 +5,12 @@
 
 package org.opensearch.notifications
 
-import org.opensearch.common.xcontent.DeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
-import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.xcontent.DeprecationHandler
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentParser
 import java.io.ByteArrayOutputStream
 
 fun getJsonString(xContent: ToXContent): String {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.opensearch.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
-import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.destination.response.LegacyDestinationResponse
 import org.opensearch.commons.notifications.action.BaseResponse
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
@@ -44,6 +43,7 @@ import org.opensearch.commons.notifications.model.EventStatus
 import org.opensearch.commons.notifications.model.NotificationConfigSearchResult
 import org.opensearch.commons.notifications.model.NotificationEvent
 import org.opensearch.commons.notifications.model.SeverityType
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.notifications.send.SendMessageActionHelper
 import org.opensearch.rest.RestStatus
@@ -83,7 +83,10 @@ internal class PluginActionTests {
         } returns response
 
         val createNotificationConfigAction = CreateNotificationConfigAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         createNotificationConfigAction.execute(task, request, AssertionListener(response))
     }
@@ -103,7 +106,10 @@ internal class PluginActionTests {
         } returns response
 
         val updateNotificationConfigAction = UpdateNotificationConfigAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         updateNotificationConfigAction.execute(task, request, AssertionListener(response))
     }
@@ -124,7 +130,10 @@ internal class PluginActionTests {
         } returns response
 
         val deleteNotificationConfigAction = DeleteNotificationConfigAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         deleteNotificationConfigAction.execute(task, request, AssertionListener(response))
     }
@@ -145,7 +154,10 @@ internal class PluginActionTests {
         } returns response
 
         val getNotificationConfigAction = GetNotificationConfigAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         getNotificationConfigAction.execute(task, request, AssertionListener(response))
     }
@@ -158,7 +170,10 @@ internal class PluginActionTests {
         val response = GetPluginFeaturesResponse(allowedConfigTypes, pluginFeatures)
 
         val getPluginFeaturesAction = GetPluginFeaturesAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         getPluginFeaturesAction.execute(task, request, AssertionListener(response))
     }
@@ -177,7 +192,10 @@ internal class PluginActionTests {
         } returns response
 
         val getChannelListAction = GetChannelListAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         getChannelListAction.execute(task, request, AssertionListener(response))
     }
@@ -212,7 +230,10 @@ internal class PluginActionTests {
         } returns response
 
         val sendNotificationAction = SendNotificationAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         sendNotificationAction.execute(task, request, AssertionListener(response))
     }
@@ -229,7 +250,10 @@ internal class PluginActionTests {
         every { SendMessageActionHelper.executeLegacyRequest(request) } returns response
 
         val publishNotificationAction = PublishNotificationAction(
-            transportService, client, actionFilters, xContentRegistry
+            transportService,
+            client,
+            actionFilters,
+            xContentRegistry
         )
         publishNotificationAction.execute(task, request, AssertionListener(response))
     }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -79,7 +79,7 @@ internal class PluginSettingsTests {
                 clusterSettings,
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
-                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT
                 )
             )
         )


### PR DESCRIPTION
### Description
Main branch build fails due to:
Xcontent classes were moved in this PR https://github.com/opensearch-project/OpenSearch/pull/5902

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
