### PR TITLE
upgrade mockito and byte-buddy version to align with opensearch core and Fix BWC test case failure

### DIFF
--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -73,9 +73,9 @@ jobs:
         if: env.imagePresent == 'true'
         run: |
           cd ..
-          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-notifications:test
+          container_id=`docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-notifications:test`
           sleep 120
-
+          echo `docker logs $container_id`
       - name: Run Notification Test for security enabled test cases
         if: env.imagePresent == 'true'
         run: |

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
-    testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
+    testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
-    testImplementation "org.mockito:mockito-core:5.1.0"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
     implementation project(path: ":${rootProject.name}-core-spi", configuration: 'shadow')

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -260,14 +260,11 @@ testClusters.integTest {
 }
 
 // Always be minimumCompatibilityVersion of current opensearch version(3.0.0)
-def bwcVersion = "2.7.0"
-def bwcPluginVersion= bwcVersion + ".0" + "-SNAPSHOT"
-def bwcVersionSnapshot = bwcVersion + "-SNAPSHOT"
+def bwcVersionShort = "2.7.0"
+def bwcVersion = bwcVersionShort + ".0"
+def bwcOpenSearchVesion= bwcVersionShort + "-SNAPSHOT"
+def bwcPluginVersion = bwcVersion + "-SNAPSHOT"
 String baseName = "notificationsBwcCluster"
-
-String bwcPluginsResourcePath = "src/test/resources/plugins/bwc"
-String bwcNotificationsCoreFilePath = "$bwcPluginsResourcePath/notifications-core/$bwcVersion"
-String bwcNotificationsFilePath = "$bwcPluginsResourcePath/notifications/$bwcVersion"
 
 configurations {
     opensearchPlugin
@@ -303,7 +300,7 @@ def notificationsFile = resolvePluginFile("notifications")
     testClusters {
         "${baseName}$i" {
             testDistribution = "INTEG_TEST"
-            versions = [bwcVersionSnapshot, opensearch_version]
+            versions = [bwcOpenSearchVesion, opensearch_version]
             numberOfNodes = 3
             plugin(provider(notificationsCoreFile))
             plugin(provider(notificationsFile))

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -126,8 +126,8 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}" // required by mockk
-    testImplementation "net.bytebuddy:byte-buddy-agent:1.12.7"
-    testImplementation "org.mockito:mockito-core:5.1.0"
+    testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation 'com.google.code.gson:gson:2.8.9'
     testImplementation 'org.springframework.integration:spring-integration-mail:5.5.0'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.5.0'

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -259,61 +259,54 @@ testClusters.integTest {
     setting 'path.repo', repo.absolutePath
 }
 
-String bwcVersion = "2.5.0.0"
+// Always be minimumCompatibilityVersion of current opensearch version(3.0.0)
+def bwcVersion = "2.7.0"
+def bwcPluginVersion= bwcVersion + ".0" + "-SNAPSHOT"
+def bwcVersionSnapshot = bwcVersion + "-SNAPSHOT"
 String baseName = "notificationsBwcCluster"
 
 String bwcPluginsResourcePath = "src/test/resources/plugins/bwc"
 String bwcNotificationsCoreFilePath = "$bwcPluginsResourcePath/notifications-core/$bwcVersion"
 String bwcNotificationsFilePath = "$bwcPluginsResourcePath/notifications/$bwcVersion"
-String bwcNotificationsCoreDownload = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/" +
-        "2.5.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-notifications-core-" +
-        bwcVersion + ".zip"
-String bwcNotificationsDownload = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/" +
-        "2.5.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-notifications-" +
-        bwcVersion + ".zip"
+
+configurations {
+    opensearchPlugin
+}
+
+dependencies {
+    opensearchPlugin "org.opensearch.plugin:opensearch-notifications-core:${bwcPluginVersion}@zip"
+    opensearchPlugin "org.opensearch.plugin:notifications:${bwcPluginVersion}@zip"
+}
+
+ext.resolvePluginFile = { pluginId ->
+    return new Callable<RegularFile>() {
+        @Override
+        RegularFile call() throws Exception {
+            return new RegularFile() {
+                @Override
+                File getAsFile() {
+                    return configurations.opensearchPlugin.resolvedConfiguration.resolvedArtifacts
+                            .find { ResolvedArtifact f ->
+                                f.name.startsWith(pluginId)
+                            }
+                            .file
+                }
+            }
+        }
+    }
+}
+
+def notificationsCoreFile = resolvePluginFile("opensearch-notifications-core")
+def notificationsFile = resolvePluginFile("notifications")
 
 2.times { i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "INTEG_TEST"
-            versions = ["2.5.0-SNAPSHOT", opensearch_version]
+            versions = [bwcVersionSnapshot, opensearch_version]
             numberOfNodes = 3
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            if (new File("$project.rootDir/$bwcNotificationsCoreFilePath").exists()) {
-                                project.delete(files("$project.rootDir/$bwcNotificationsCoreFilePath"))
-                            }
-                            project.mkdir bwcNotificationsCoreFilePath
-                            ant.get(src: bwcNotificationsCoreDownload,
-                                    dest: bwcNotificationsCoreFilePath,
-                                    httpusecaches: false)
-                            return fileTree(bwcNotificationsCoreFilePath).getSingleFile()
-                        }
-                    }
-                }
-            }))
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            if (new File("$project.rootDir/$bwcNotificationsFilePath").exists()) {
-                                project.delete(files("$project.rootDir/$bwcNotificationsFilePath"))
-                            }
-                            project.mkdir bwcNotificationsFilePath
-                            ant.get(src: bwcNotificationsDownload,
-                                    dest: bwcNotificationsFilePath,
-                                    httpusecaches: false)
-                            return fileTree(bwcNotificationsFilePath).getSingleFile()
-                        }
-                    }
-                }
-            }))
+            plugin(provider(notificationsCoreFile))
+            plugin(provider(notificationsFile))
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
         }


### PR DESCRIPTION
### Description
1. upgrade mockito and byte-buddy version to align with opensearch core
https://github.com/opensearch-project/OpenSearch/pull/6678

2. To fix the BWC test case failure, we upgraded the BWC OpenSearch version to 2.7.0. The reason for this upgrade is that OpenSearch 3.0.0 will only be compatible with the latest version of 2.x, which for the time being is 2.7.0. Once we have a newer version, such as 2.8.0, we will need to upgrade to that version.
3. Enable debug log for security run with docker

### Issues Resolved
#643, #641 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
