### PR TITLE
bump bwc version to 2.8.0

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -96,6 +96,8 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     main = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "notifications/**/*.kt", "core/**/*.kt", "core-spi/**/*.kt"
+    // https://github.com/pinterest/ktlint/issues/1391
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
 }
 
 // TODO: enable detekt only when snakeyaml vulnerability is fixed
@@ -119,12 +121,5 @@ task updateVersion {
         println "Setting version to ${newVersion}."
          // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
-        ant.replaceregexp(file:'../.github/workflows/dashboards-notifications-test-and-build-workflow.yml', match:'OPENSEARCH_PLUGIN_VERSION: \\d+.\\d+.\\d+.\\d+', replace:'OPENSEARCH_PLUGIN_VERSION: ' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
-        ant.replaceregexp(file:'../.github/workflows/draft-release-notes-workflow.yml', match:'version: \\d+.\\d+.\\d+.\\d+', replace:'version: ' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
-        // Match key version in JSON files.
-        ant.replaceregexp(file:'../dashboards-notifications/opensearch_dashboards.json', match:'"version": "\\d+.\\d+.\\d+.\\d+', replace:'"version": ' + '"' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
-        ant.replaceregexp(file:'../dashboards-notifications/package.json', match:'"version": "\\d+.\\d+.\\d+.\\d+', replace:'"version": ' + '"' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
-        // Match key opensearchDashboardsVersion in JSON files.
-        ant.replaceregexp(file:'../dashboards-notifications/opensearch_dashboards.json', match:'"opensearchDashboardsVersion": "\\d+.\\d+.\\d+', replace:'"opensearchDashboardsVersion": ' + '"' + newVersion.tokenize('-')[0], flags:'g', byline:true)
     }
 }

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -224,7 +224,7 @@ afterEvaluate {
     }
 
     buildDeb {
-        arch = 'amd64'
+        arch = 'all'
         dependsOn 'assemble'
         finalizedBy 'renameDeb'
         task renameDeb(type: Copy) {

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -226,7 +226,7 @@ afterEvaluate {
     buildDeb {
         arch = 'amd64'
         dependsOn 'assemble'
-        finalizedBy 'renameRpm'
+        finalizedBy 'renameDeb'
         task renameDeb(type: Copy) {
             from("$buildDir/distributions")
             into("$buildDir/distributions")

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -265,7 +265,7 @@ testClusters.integTest {
 }
 
 // Always be minimumCompatibilityVersion of current opensearch version(3.0.0)
-def bwcVersionShort = "2.7.0"
+def bwcVersionShort = "2.8.0"
 def bwcVersion = bwcVersionShort + ".0"
 def bwcOpenSearchVesion= bwcVersionShort + "-SNAPSHOT"
 def bwcPluginVersion = bwcVersion + "-SNAPSHOT"
@@ -473,7 +473,7 @@ afterEvaluate {
         arch = 'NOARCH'
         dependsOn 'assemble'
         finalizedBy 'renameRpm'
-        task renameRpm {
+        task renameRpm(type: Copy) {
             from("$buildDir/distributions")
             into("$buildDir/distributions")
             rename "$archiveFileName", "${packageName}-${version}.rpm"

--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -10,4 +10,4 @@ include ":core-spi"
 
 project(":core").name = rootProject.name + "-core"
 project(":core-spi").name = rootProject.name + "-core" + "-spi"
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal"]
+startParameter.excludedTaskNames += ["publishPluginZipPublicationToMavenLocal"]


### PR DESCRIPTION
### Description
Bump bwc version to 2.8.0 as latest version of 2.x is [2.8.0](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/Version.java#L95) now

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
