### PR TITLE
Fix default email size limit bug to make the limit consistent between bindle file and code

### DIFF
--- a/notifications/core/src/main/config/notifications-core.yml
+++ b/notifications/core/src/main/config/notifications-core.yml
@@ -7,8 +7,8 @@
 # configuration file for the notifications-core plugin
 opensearch.notifications.core:
   email:
-    size_limit: 10000
-    minimum_header_length: 100
+    size_limit: 10000000
+    minimum_header_length: 160
   http:
     max_connections: 60
     max_connection_per_route: 20


### PR DESCRIPTION

### Description
Modify some default values in the bindle file `notifications-core.yml` to make them consistent with the values in code, there are two values not consistent with the code:
1. default size limit of email: currently 10000, actually 10000000.
2. minimum header length of email: currently 100, actually 160.

### Issues Resolved
#658 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
