### PR TITLE
Fix gradle run failed on windows platform

### DIFF
--- a/notifications/build-tools/plugin-coverage.gradle
+++ b/notifications/build-tools/plugin-coverage.gradle
@@ -65,7 +65,7 @@ allprojects{
         testClusters.integTest {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 // Replacing build with absolute path to fix the error "error opening zip file or JAR manifest missing : /build/tmp/expandedArchives/..../jacocoagent.jar"
-                jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('build',"${buildDir}")
+                // jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('build',"${buildDir}")
             } else {
                 jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('javaagent:','javaagent:/')
             }


### PR DESCRIPTION
### Description
Fix can't run Gradle run in window platform.

the error happened on windows is 

> Task :notifications:run FAILED
| Output for cmd:"warning: no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release" 
| Error opening zip file or JAR manifest missing : D:\a\dashboards-notifications\dashboards-notifications\notifications\notifications\notifications\D:\a\dashboards-notifications\dashboards-notifications\notifications\notifications\notifications\build\tmp\.cache\expanded\zip_3a83c50b4a016f281c4e9f3500d16b55\jacocoagent.jar
Error occurred during initialization of VM
agent library failed to init: instrument

### Issues Resolved
https://github.com/opensearch-project/dashboards-notifications/actions/runs/5042626508/jobs/9043454391?pr=46

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
