### PR TITLE
Fix weak password test failure

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -242,8 +242,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         client().performRequest(request)
     }
 
-    fun createUserWithRoles(user: String, role: String, backendRole: String) {
-        createUser(user, user, arrayOf(backendRole))
+    fun createUserWithRoles(user: String, password: String, role: String, backendRole: String) {
+        createUser(user, password, arrayOf(backendRole))
         addPatchUserRolesMapping(role, arrayOf(user))
     }
 
@@ -254,11 +254,12 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
 
     fun createUserWithCustomRole(
         user: String,
+        password: String,
         role: String,
         backendRole: String,
         clusterPermissions: String?
     ) {
-        createUser(user, user, arrayOf(backendRole))
+        createUser(user, password, arrayOf(backendRole))
         createCustomRole(role, clusterPermissions)
         createUserRolesMapping(role, arrayOf(user))
     }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/SecurityNotificationIT.kt
@@ -31,13 +31,14 @@ class SecurityNotificationIT : PluginRestTestCase() {
         }
     }
 
-    val user = "integTestUser"
+    private val user = "integTestUser"
+    private val password = randomAlphaOfLength(6) + "_" + randomIntBetween(1000, 10000) + "!" + randomAlphaOfLength(10)
     var userClient: RestClient? = null
 
     @Before
     fun create() {
-        createUser(user, user, arrayOf())
-        userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, user)
+        createUser(user, password, arrayOf())
+        userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, password)
             .setSocketTimeout(60000)
             .setConnectionRequestTimeout(180000)
             .build()
@@ -50,7 +51,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test Create slack notification config with user that has create Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_CREATE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_CREATE_CONFIG_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_CREATE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_CREATE_CONFIG_ACCESS])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -93,7 +94,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test Create slack notification config without create Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -129,7 +130,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test update slack notification config with user that has create Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_UPDATE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_UPDATE_CONFIG_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_UPDATE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_UPDATE_CONFIG_ACCESS])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -206,7 +207,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test update slack notification config without create Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -242,7 +243,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test get slack notification config with user that has get Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_GET_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_CONFIG_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_GET_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_CONFIG_ACCESS])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -283,7 +284,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test get slack notification config without get Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         // Get Slack notification config
 
@@ -298,7 +299,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test delete slack notification config with user that has get Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_DELETE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_DELETE_CONFIG_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_DELETE_CONFIG_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_DELETE_CONFIG_ACCESS])
 
         // Create sample config request reference
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
@@ -341,7 +342,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test delete slack notification config without get Notification permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         // Get Slack notification config
 
@@ -356,7 +357,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test getChannelList should return only channels with get channel permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_GET_CHANNEL_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_CHANNEL_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_GET_CHANNEL_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_CHANNEL_ACCESS])
 
         val slackId = createConfig(configType = ConfigType.SLACK)
         val chimeId = createConfig(configType = ConfigType.CHIME)
@@ -385,7 +386,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test getChannelList fails without get channel permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         createConfig(configType = ConfigType.SLACK)
         Thread.sleep(1000)
@@ -402,7 +403,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test Get plugin features should return non-empty configTypes with get features permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_GET_PLUGIN_FEATURE_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_PLUGIN_FEATURE_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_GET_PLUGIN_FEATURE_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_GET_PLUGIN_FEATURE_ACCESS])
 
         val getResponse = executeRequest(
             RestRequest.Method.GET.name,
@@ -418,7 +419,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test Get plugin features fails without get features permission`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         executeRequest(
             RestRequest.Method.GET.name,
@@ -431,7 +432,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test send test slack message with send permissions`() {
-        createUserWithCustomRole(user, NOTIFICATION_TEST_SEND_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_TEST_SEND_ACCESS])
+        createUserWithCustomRole(user, password, NOTIFICATION_TEST_SEND_ACCESS, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_TEST_SEND_ACCESS])
 
         // Create webhook notification config
         val createRequestJsonString = """
@@ -469,7 +470,7 @@ class SecurityNotificationIT : PluginRestTestCase() {
     }
 
     fun `test send test slack message without send permissions`() {
-        createUserWithCustomRole(user, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
+        createUserWithCustomRole(user, password, NOTIFICATION_NO_ACCESS_ROLE, "", ROLE_TO_PERMISSION_MAPPING[NOTIFICATION_NO_ACCESS_ROLE])
 
         // Create webhook notification config
         val createRequestJsonString = """


### PR DESCRIPTION
### Description
Found that there is a new feature introduced in version 2.8 of security plugin, when creating an user, if the password is weak,  it will return 400 bad request directly. But in SecurityNotificationIT, we use a weak password, so all of the test cases will fail, this pr fix this problem by using a strong password generated by random strings.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
