### PR TITLE
Add html sanitization enhancement for email message

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/MessageContent.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/MessageContent.kt
@@ -23,10 +23,16 @@ class MessageContent(
 
     init {
         require(!Strings.isNullOrEmpty(title)) { "title is null or empty" }
-        require(!Strings.isNullOrEmpty(textDescription)) { "text message part is null or empty" }
+        require(!Strings.isNullOrEmpty(textDescription) || !Strings.isNullOrEmpty(htmlDescription)) {
+            "both text message part and html message part are null or empty"
+        }
     }
 
     fun buildMessageWithTitle(): String {
-        return "$title\n\n$textDescription"
+        return if (!Strings.isNullOrEmpty(htmlDescription)) {
+            htmlDescription!!
+        } else {
+            "$title\n\n$textDescription"
+        }
     }
 }

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -146,6 +146,8 @@ dependencies {
     implementation "com.sun.mail:javax.mail:1.6.2"
     implementation "javax.activation:activation:1.1"
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
+    implementation "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1"
+    api 'com.google.guava:guava:32.0.0-jre'
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',

--- a/notifications/core/src/main/config/notifications-core.yml
+++ b/notifications/core/src/main/config/notifications-core.yml
@@ -9,6 +9,8 @@ opensearch.notifications.core:
   email:
     size_limit: 10000000
     minimum_header_length: 160
+    enable_html_sanitization: true
+    html_sanitization_allow_list: ["blocks_group", "formatting_group", "images_group", "links_group", "styles_group", "tables_group"]
   http:
     max_connections: 60
     max_connection_per_route: 20

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/EmailMimeProvider.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/EmailMimeProvider.kt
@@ -5,7 +5,13 @@
 
 package org.opensearch.notifications.core.client
 
+import org.opensearch.notifications.core.setting.PluginSettings
+import org.opensearch.notifications.core.utils.logger
 import org.opensearch.notifications.spi.model.MessageContent
+import org.owasp.html.AttributePolicy
+import org.owasp.html.HtmlChangeListener
+import org.owasp.html.HtmlPolicyBuilder
+import org.owasp.html.PolicyFactory
 import java.util.Base64
 import javax.activation.DataHandler
 import javax.mail.Message
@@ -19,6 +25,86 @@ import javax.mail.util.ByteArrayDataSource
  * Object for creating mime mimeMessage from the channel mimeMessage for sending mail.
  */
 internal object EmailMimeProvider {
+    private val log by logger(EmailMimeProvider::class.java)
+
+    // org.owasp.html.Sanitizers provide some default sanitizers which can be used directly,
+    // we define these html elements groups and map them to the default sanitizers, users can specify these groups in the allow list,
+    // and users can still specify individual html tags or elements in the allow list or deny list
+    private const val HTML_ELEMENTS_GROUP_BLOCKS = "blocks_group"
+    private const val HTML_ELEMENTS_GROUP_FORMATTING = "formatting_group"
+    private const val HTML_ELEMENTS_GROUP_IMAGES = "images_group"
+    private const val HTML_ELEMENTS_GROUP_LINKS = "links_group"
+    private const val HTML_ELEMENTS_GROUP_STYLES = "styles_group"
+    private const val HTML_ELEMENTS_GROUP_TABLES = "tables_group"
+
+    // copied from org.owasp.html.Sanitizers.INTEGER
+    private val INTEGER = AttributePolicy { _, _, value ->
+        val n = value.length
+        if (n == 0) {
+            return@AttributePolicy null
+        }
+        for (i in 0 until n) {
+            val ch = value[i]
+            if (ch == '.') {
+                return@AttributePolicy if (i == 0) {
+                    null
+                } else value.substring(0, i)
+                // truncate to integer.
+            } else if (ch !in '0'..'9') {
+                return@AttributePolicy null
+            }
+        }
+        value
+    }
+    private val htmlSanitizationPolicy: PolicyFactory?
+        get() {
+            if (PluginSettings.enableEmailHtmlSanitization) {
+                var policyBuilder = HtmlPolicyBuilder()
+                if (PluginSettings.emailHtmlSanitizationAllowList.isNotEmpty()) {
+                    PluginSettings.emailHtmlSanitizationAllowList.forEach { e ->
+                        when (e) {
+                            // we do not use the pre-defined sanitizers directly but copy the definition here,
+                            // because found that deny list takes no effect if we use the pre-defined sanitizers
+                            HTML_ELEMENTS_GROUP_BLOCKS -> policyBuilder = policyBuilder.allowCommonBlockElements()
+                            HTML_ELEMENTS_GROUP_FORMATTING -> policyBuilder = policyBuilder.allowCommonInlineFormattingElements()
+                            HTML_ELEMENTS_GROUP_IMAGES -> policyBuilder = policyBuilder.allowUrlProtocols("http", "https").allowElements("img")
+                                .allowAttributes("alt", "src").onElements("img")
+                                .allowAttributes("border", "height", "width").matching(INTEGER)
+                                .onElements("img")
+                            HTML_ELEMENTS_GROUP_LINKS -> policyBuilder = policyBuilder.allowStandardUrlProtocols().allowElements("a")
+                                .allowAttributes("href").onElements("a").requireRelNofollowOnLinks()
+                            HTML_ELEMENTS_GROUP_STYLES -> policyBuilder = policyBuilder.allowStyling()
+                            HTML_ELEMENTS_GROUP_TABLES -> policyBuilder = policyBuilder.allowStandardUrlProtocols()
+                                .allowElements(
+                                    "table", "tr", "td", "th",
+                                    "colgroup", "caption", "col",
+                                    "thead", "tbody", "tfoot"
+                                )
+                                .allowAttributes("summary").onElements("table")
+                                .allowAttributes("align", "valign")
+                                .onElements(
+                                    "table", "tr", "td", "th",
+                                    "colgroup", "col",
+                                    "thead", "tbody", "tfoot"
+                                )
+                                .allowTextIn("table")
+                            else -> policyBuilder = policyBuilder.allowElements(e)
+                        }
+                    }
+                }
+
+                if (PluginSettings.emailHtmlSanitizationDenyList.isNotEmpty()) {
+                    // deny list only accepts individual html tags or elements
+                    PluginSettings.emailHtmlSanitizationDenyList.forEach { e ->
+                        policyBuilder = policyBuilder.disallowElements(e)
+                    }
+                }
+
+                return policyBuilder.toFactory()
+            }
+            return null
+        }
+
     /**
      * Create and prepare mime mimeMessage to send mail
      * @param session The mail session to use to create mime mimeMessage
@@ -60,7 +146,33 @@ internal object EmailMimeProvider {
         // Define the HTML part
         if (messageContent.htmlDescription != null) {
             val htmlPart = MimeBodyPart()
-            htmlPart.setContent(messageContent.htmlDescription, "text/html; charset=UTF-8")
+            if (PluginSettings.enableEmailHtmlSanitization && htmlSanitizationPolicy != null) {
+                log.info(
+                    "html sanitization for email enabled, allow list: [" + PluginSettings.emailHtmlSanitizationAllowList.joinToString() + "], deny list: [" +
+                        PluginSettings.emailHtmlSanitizationDenyList.joinToString() + "], will sanitize the html body of the email from $fromAddress to $recipient"
+                )
+                val sanitizedHtml = htmlSanitizationPolicy!!.sanitize(
+                    messageContent.htmlDescription,
+                    object : HtmlChangeListener<String> {
+                        override fun discardedTag(context: String?, elementName: String) {
+                            log.debug("html sanitization for email, discard tag: $elementName")
+                        }
+
+                        override fun discardedAttributes(
+                            context: String?,
+                            elementName: String,
+                            vararg attributeNames: String
+                        ) {
+                            log.debug("html sanitization for email, discard attributes: $attributeNames")
+                        }
+                    },
+                    null
+                )
+                htmlPart.setContent(sanitizedHtml, "text/html; charset=UTF-8")
+            } else {
+                htmlPart.setContent(messageContent.htmlDescription, "text/html; charset=UTF-8")
+            }
+
             // Add the HTML part to the child container
             msgBody.addBodyPart(htmlPart)
         }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -166,7 +166,7 @@ internal class ChimeDestinationTests {
         val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
             MessageContent("title", "")
         }
-        assertEquals("text message part is null or empty", exception.message)
+        assertEquals("both text message part and html message part are null or empty", exception.message)
     }
 
     @ParameterizedTest

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/EmailMimeProviderTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/EmailMimeProviderTests.kt
@@ -1,0 +1,235 @@
+package org.opensearch.notifications.core.destinations
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.opensearch.notifications.core.client.EmailMimeProvider
+import org.opensearch.notifications.core.setting.PluginSettings
+import org.opensearch.notifications.spi.model.MessageContent
+import java.io.ByteArrayOutputStream
+import java.util.Properties
+import javax.mail.Session
+
+internal class EmailMimeProviderTests {
+    @AfterEach
+    fun reset() {
+        PluginSettings.reset()
+    }
+
+    @Test
+    // Use default config to sanitize html,
+    // h1, p and other basic elements will be kept, images and links will be kept,
+    // but script and iframe will be sanitized
+    fun testPrepareMimeMessageWithDefaultHTMLSanitizationConfig() {
+        val prop = Properties()
+        prop["mail.transport.protocol"] = "smtp"
+        prop["mail.smtp.host"] = "0.0.0.0"
+        prop["mail.smtp.port"] = "587"
+        val session = Session.getInstance(prop)
+        val subject = "Test sending HTML email subject"
+        val htmlBody = "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "<script>\n" +
+            "document.getElementById(\"demo\").innerHTML = \"Test script for html sanitization\";\n" +
+            "</script>\n" +
+            "<a href=\"https://a.com/x\">\n" +
+            "Test link for html sanitization\n" +
+            "</a>\n" +
+            "<iframe src=\"test iframe url\" title=\"Test iframe for html sanitization\">\n" +
+            "</iframe>\n" +
+            "<img src=\"x.jpg\" alt=\"Test image for html sanitization\">\n"
+
+        val message = MessageContent(subject, "", htmlBody)
+        val sanitizedMimeMessage =
+            EmailMimeProvider.prepareMimeMessage(session, "from@from.com", "recipient@recipient.com", message)
+        val outputStream = ByteArrayOutputStream()
+        sanitizedMimeMessage.writeTo(outputStream)
+        val sanitizedMessageStr = outputStream.toString()
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test sending HTML email body"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Hello OpenSearch."))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<img src="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test image for html sanitization"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<a href="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test link for html sanitization"))
+
+        Assertions.assertFalse(sanitizedMessageStr.contains("<script>"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test script for html sanitization"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<iframe src="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test iframe for html sanitization"))
+    }
+
+    @Test
+    // Test prepare mime message without html sanitization
+    fun testPrepareMimeMessageWithoutHTMLSanitization() {
+        PluginSettings.enableEmailHtmlSanitization = false
+
+        val prop = Properties()
+        prop["mail.transport.protocol"] = "smtp"
+        prop["mail.smtp.host"] = "0.0.0.0"
+        prop["mail.smtp.port"] = "587"
+        val session = Session.getInstance(prop)
+        val subject = "Test sending HTML email subject"
+        val htmlBody = "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "<script>\n" +
+            "document.getElementById(\"demo\").innerHTML = \"Test script for html sanitization\";\n" +
+            "</script>\n" +
+            "<a href=\"https://a.com/x\">\n" +
+            "Test link for html sanitization\n" +
+            "</a>\n" +
+            "<iframe src=\"test iframe url\" title=\"Test iframe for html sanitization\">\n" +
+            "</iframe>\n" +
+            "<img src=\"x.jpg\" alt=\"Test image for html sanitization\">\n"
+
+        val message = MessageContent(subject, "", htmlBody)
+        val sanitizedMimeMessage =
+            EmailMimeProvider.prepareMimeMessage(session, "from@from.com", "recipient@recipient.com", message)
+        val outputStream = ByteArrayOutputStream()
+        sanitizedMimeMessage.writeTo(outputStream)
+        val sanitizedMessageStr = outputStream.toString()
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test sending HTML email body"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Hello OpenSearch."))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<img src="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test image for html sanitization"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<a href="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test link for html sanitization"))
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("<script>"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test script for html sanitization"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<iframe src="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test iframe for html sanitization"))
+    }
+
+    @Test
+    // Test prepare mime message with custom html sanitization allow list
+    fun testPrepareMimeMessageWithCustomHtmlSanitizationAllowList() {
+        PluginSettings.emailHtmlSanitizationAllowList = listOf("h1", "p")
+
+        val prop = Properties()
+        prop["mail.transport.protocol"] = "smtp"
+        prop["mail.smtp.host"] = "0.0.0.0"
+        prop["mail.smtp.port"] = "587"
+        val session = Session.getInstance(prop)
+        val subject = "Test sending HTML email subject"
+        val htmlBody = "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "<script>\n" +
+            "document.getElementById(\"demo\").innerHTML = \"Test script for html sanitization\";\n" +
+            "</script>\n" +
+            "<a href=\"https://a.com/x\">\n" +
+            "Test link for html sanitization\n" +
+            "</a>\n" +
+            "<iframe src=\"test iframe url\" title=\"Test iframe for html sanitization\">\n" +
+            "</iframe>\n" +
+            "<img src=\"x.jpg\" alt=\"Test image for html sanitization\">\n"
+
+        val message = MessageContent(subject, "", htmlBody)
+        val sanitizedMimeMessage =
+            EmailMimeProvider.prepareMimeMessage(session, "from@from.com", "recipient@recipient.com", message)
+        val outputStream = ByteArrayOutputStream()
+        sanitizedMimeMessage.writeTo(outputStream)
+        val sanitizedMessageStr = outputStream.toString()
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test sending HTML email body"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Hello OpenSearch."))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test link for html sanitization"))
+
+        Assertions.assertFalse(sanitizedMessageStr.contains("<img src="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test image for html sanitization"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<a href="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<script>"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test script for html sanitization"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<iframe src="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test iframe for html sanitization"))
+    }
+    @Test
+    // Test prepare mime message with custom html sanitization deny list
+    fun testPrepareMimeMessageWithCustomHtmlSanitizationDenyList() {
+        PluginSettings.emailHtmlSanitizationAllowList = listOf("blocks_group", "links_group", "images_group")
+        PluginSettings.emailHtmlSanitizationDenyList = listOf("h2", "h3")
+
+        val prop = Properties()
+        prop["mail.transport.protocol"] = "smtp"
+        prop["mail.smtp.host"] = "0.0.0.0"
+        prop["mail.smtp.port"] = "587"
+        val session = Session.getInstance(prop)
+        val subject = "Test sending HTML email subject"
+        val htmlBody = "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "<h2>test head2</h2>\n" +
+            "<h3>test head3</h3>\n" +
+            "<a href=\"https://a.com/x\">\n" +
+            "Test link for html sanitization\n" +
+            "</a>\n" +
+            "<img src=\"x.jpg\" alt=\"Test image for html sanitization\">\n"
+
+        val message = MessageContent(subject, "", htmlBody)
+        val sanitizedMimeMessage =
+            EmailMimeProvider.prepareMimeMessage(session, "from@from.com", "recipient@recipient.com", message)
+        val outputStream = ByteArrayOutputStream()
+        sanitizedMimeMessage.writeTo(outputStream)
+        val sanitizedMessageStr = outputStream.toString()
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("<h1>"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test sending HTML email body"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<p>"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Hello OpenSearch."))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<a href="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("<img src="))
+        Assertions.assertTrue(sanitizedMessageStr.contains("test head2"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("test head3"))
+
+        Assertions.assertFalse(sanitizedMessageStr.contains("<h2>"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<h3>"))
+    }
+
+    @Test
+    // Test prepare mime message with empty html sanitization allow list and deny list
+    fun testPrepareMimeMessageWithEmptyHtmlSanitizationDenyList() {
+        PluginSettings.emailHtmlSanitizationAllowList = emptyList()
+        PluginSettings.emailHtmlSanitizationDenyList = emptyList()
+
+        val prop = Properties()
+        prop["mail.transport.protocol"] = "smtp"
+        prop["mail.smtp.host"] = "0.0.0.0"
+        prop["mail.smtp.port"] = "587"
+        val session = Session.getInstance(prop)
+        val subject = "Test sending HTML email subject"
+        val htmlBody = "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "<script>\n" +
+            "document.getElementById(\"demo\").innerHTML = \"Test script for html sanitization\";\n" +
+            "</script>\n" +
+            "<a href=\"https://a.com/x\">\n" +
+            "Test link for html sanitization\n" +
+            "</a>\n" +
+            "<iframe src=\"test iframe url\" title=\"Test iframe for html sanitization\">\n" +
+            "</iframe>\n" +
+            "<img src=\"x.jpg\" alt=\"Test image for html sanitization\">\n"
+
+        val message = MessageContent(subject, "", htmlBody)
+        val sanitizedMimeMessage =
+            EmailMimeProvider.prepareMimeMessage(session, "from@from.com", "recipient@recipient.com", message)
+        val outputStream = ByteArrayOutputStream()
+        sanitizedMimeMessage.writeTo(outputStream)
+        val sanitizedMessageStr = outputStream.toString()
+
+        Assertions.assertTrue(sanitizedMessageStr.contains("Test sending HTML email body"))
+        Assertions.assertTrue(sanitizedMessageStr.contains("Hello OpenSearch."))
+
+        Assertions.assertFalse(sanitizedMessageStr.contains("<img src="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test image for html sanitization"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<a href="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<script>"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test script for html sanitization"))
+        Assertions.assertFalse(sanitizedMessageStr.contains("<iframe src="))
+        Assertions.assertFalse(sanitizedMessageStr.contains("Test iframe for html sanitization"))
+    }
+}

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SesDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SesDestinationTests.kt
@@ -1,0 +1,88 @@
+package org.opensearch.notifications.core.destinations
+
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.easymock.EasyMock
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.opensearch.notifications.core.NotificationCoreImpl
+import org.opensearch.notifications.core.client.DestinationSesClient
+import org.opensearch.notifications.core.credentials.SesClientFactory
+import org.opensearch.notifications.core.transport.DestinationTransportProvider
+import org.opensearch.notifications.core.transport.SesDestinationTransport
+import org.opensearch.notifications.spi.model.DestinationMessageResponse
+import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.DestinationType
+import org.opensearch.notifications.spi.model.destination.SesDestination
+import org.opensearch.rest.RestStatus
+
+@ExtendWith(MockitoExtension::class)
+internal class SesDestinationTests {
+    @Test
+    fun testSesEmailMessage() {
+        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK.status, "Success:test-message-id")
+        val mockSesClientFactory: SesClientFactory = EasyMock.createMock(SesClientFactory::class.java)
+        val sesClient = spyk(DestinationSesClient(mockSesClientFactory))
+
+        val result: SendRawEmailResult = mockk()
+        every { result.messageId } returns "test-message-id"
+        val response: DestinationMessageResponse = mockk()
+        every { sesClient.execute(any(), any(), any()) } returns response
+        every { response.statusCode } returns RestStatus.OK.status
+        every { response.statusText } returns "Success:${result.messageId}"
+
+        val sesEmailDestinationTransport = SesDestinationTransport(sesClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.SES to sesEmailDestinationTransport)
+
+        val subject = "Test SES Email subject"
+        val messageText = "{Message gughjhjlkh Body emoji test: :) :+1: " +
+            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+            "@All All Present member callout: @Present}"
+        val message = MessageContent(subject, messageText)
+        val roleArn = "arn:aws:iam::012345678912:role/iam-test"
+        val destination = SesDestination("testAccountName", "us-east-1", roleArn, "test@from.com", "to@abc.com")
+
+        val actualEmailResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+        Assertions.assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
+        Assertions.assertEquals(expectedEmailResponse.statusText, actualEmailResponse.statusText)
+    }
+
+    @Test
+    fun testSesEmailHtmlMessage() {
+        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK.status, "Success:test-message-id")
+        val mockSesClientFactory: SesClientFactory = EasyMock.createMock(SesClientFactory::class.java)
+        val sesClient = spyk(DestinationSesClient(mockSesClientFactory))
+
+        val result: SendRawEmailResult = mockk()
+        every { result.messageId } returns "test-message-id"
+        val response: DestinationMessageResponse = mockk()
+        every { sesClient.execute(any(), any(), any()) } returns response
+        every { response.statusCode } returns RestStatus.OK.status
+        every { response.statusText } returns "Success:${result.messageId}"
+
+        val sesEmailDestinationTransport = SesDestinationTransport(sesClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.SES to sesEmailDestinationTransport)
+
+        val subject = "Test SMTP Email with html body subject"
+        val htmlBody = "<!DOCTYPE html>\n" +
+            "<html>\n" +
+            "<body>\n" +
+            "\n" +
+            "<h1>Test sending HTML email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "\n" +
+            "</body>\n" +
+            "</html>"
+        val message = MessageContent(subject, "", htmlBody)
+        val roleArn = "arn:aws:iam::012345678912:role/iam-test"
+        val destination = SesDestination("testAccountName", "us-east-1", roleArn, "test@from.com", "to@abc.com")
+
+        val actualEmailResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+        Assertions.assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
+        Assertions.assertEquals(expectedEmailResponse.statusText, actualEmailResponse.statusText)
+    }
+}

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SmtpDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SmtpDestinationTests.kt
@@ -50,6 +50,33 @@ internal class SmtpDestinationTests {
     }
 
     @Test
+    fun testSmtpEmailHTMLMessage() {
+        val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK.status, "Success")
+        val emailClient = spyk<DestinationSmtpClient>()
+        every { emailClient.sendMessage(any()) } returns Unit
+
+        val smtpEmailDestinationTransport = SmtpDestinationTransport(emailClient)
+        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.SMTP to smtpEmailDestinationTransport)
+
+        val subject = "Test SMTP Email with html body subject"
+        val htmlBody = "<!DOCTYPE html>\n" +
+            "<html>\n" +
+            "<body>\n" +
+            "\n" +
+            "<h1>Test sending html email body</h1>\n" +
+            "<p>Hello OpenSearch.</p>\n" +
+            "\n" +
+            "</body>\n" +
+            "</html>"
+        val message = MessageContent(subject, "", htmlBody)
+        val destination = SmtpDestination("testAccountName", "abc", 465, "ssl", "test@abc.com", "to@abc.com")
+
+        val actualEmailResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "referenceId")
+        assertEquals(expectedEmailResponse.statusCode, actualEmailResponse.statusCode)
+        assertEquals(expectedEmailResponse.statusText, actualEmailResponse.statusText)
+    }
+
+    @Test
     fun `test auth email`() {
         val expectedEmailResponse = DestinationMessageResponse(RestStatus.OK.status, "Success")
         val emailClient = spyk<DestinationSmtpClient>()

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
@@ -36,6 +36,9 @@ internal class PluginSettingsTests {
     private val httpHostDenyListKey = "$httpKeyPrefix.host_deny_list"
     private val allowedConfigTypeKey = "$keyPrefix.allowed_config_types"
     private val tooltipSupportKey = "$keyPrefix.tooltip_support"
+    private val enableHtmlSanitizationKey = "$emailKeyPrefix.enable_html_sanitization"
+    private val htmlSanitizationAllowListKey = "$emailKeyPrefix.html_sanitization_allow_list"
+    private val htmlSanitizationDenyListKey = "$emailKeyPrefix.html_sanitization_deny_list"
 
     private val defaultSettings = Settings.builder()
         .put(emailSizeLimitKey, 10000000)
@@ -59,6 +62,9 @@ internal class PluginSettingsTests {
             )
         )
         .put(tooltipSupportKey, true)
+        .put(enableHtmlSanitizationKey, true)
+        .putList(htmlSanitizationAllowListKey, listOf("blocks_group", "formatting_group", "images_group", "links_group", "styles_group", "tables_group"))
+        .putList(htmlSanitizationDenyListKey, emptyList<String>())
         .build()
 
     @BeforeEach
@@ -87,7 +93,10 @@ internal class PluginSettingsTests {
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -124,6 +133,18 @@ internal class PluginSettingsTests {
             defaultSettings[httpHostDenyListKey],
             PluginSettings.hostDenyList.toString()
         )
+        Assertions.assertEquals(
+            defaultSettings[enableHtmlSanitizationKey],
+            PluginSettings.enableEmailHtmlSanitization.toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[htmlSanitizationAllowListKey],
+            PluginSettings.emailHtmlSanitizationAllowList.toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[htmlSanitizationDenyListKey],
+            PluginSettings.emailHtmlSanitizationDenyList.toString()
+        )
     }
 
     @Test
@@ -153,7 +174,10 @@ internal class PluginSettingsTests {
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -190,6 +214,18 @@ internal class PluginSettingsTests {
             false,
             clusterService.clusterSettings.get(PluginSettings.TOOLTIP_SUPPORT)
         )
+        Assertions.assertEquals(
+            true,
+            clusterService.clusterSettings.get(PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION)
+        )
+        Assertions.assertEquals(
+            listOf("blocks_group", "formatting_group", "images_group", "links_group", "styles_group", "tables_group"),
+            clusterService.clusterSettings.get(PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST)
+        )
+        Assertions.assertEquals(
+            emptyList<String>(),
+            clusterService.clusterSettings.get(PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST)
+        )
     }
 
     @Test
@@ -208,7 +244,10 @@ internal class PluginSettingsTests {
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -245,6 +284,18 @@ internal class PluginSettingsTests {
             defaultSettings[tooltipSupportKey],
             clusterService.clusterSettings.get(PluginSettings.TOOLTIP_SUPPORT).toString()
         )
+        Assertions.assertEquals(
+            defaultSettings[enableHtmlSanitizationKey],
+            clusterService.clusterSettings.get(PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION).toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[htmlSanitizationAllowListKey],
+            clusterService.clusterSettings.get(PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST).toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[htmlSanitizationDenyListKey],
+            clusterService.clusterSettings.get(PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST).toString()
+        )
     }
 
     @Test
@@ -270,7 +321,10 @@ internal class PluginSettingsTests {
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
                     PluginSettings.ALERTING_HOST_DENY_LIST,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -303,7 +357,10 @@ internal class PluginSettingsTests {
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
                     PluginSettings.ALERTING_HOST_DENY_LIST,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -335,7 +392,10 @@ internal class PluginSettingsTests {
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
                     PluginSettings.ALERTING_HOST_DENY_LIST,
-                    PluginSettings.HOST_DENY_LIST
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
                 )
             )
         )
@@ -343,6 +403,83 @@ internal class PluginSettingsTests {
         Assertions.assertEquals(
             listOf("sample"),
             clusterService.clusterSettings.get(PluginSettings.HOST_DENY_LIST)
+        )
+    }
+
+    @Test
+    fun `test html sanitization for email settings can be set at node scope`() {
+        var nodeSettings = Settings.builder()
+            .put(enableHtmlSanitizationKey, true)
+            .putList(htmlSanitizationAllowListKey, listOf("blocks_group", "links_group"))
+            .putList(htmlSanitizationDenyListKey, listOf("h1", "h2"))
+            .build()
+
+        whenever(clusterService.settings).thenReturn(nodeSettings)
+        whenever(clusterService.clusterSettings).thenReturn(
+            ClusterSettings(
+                Settings.builder().build(),
+                setOf(
+                    PluginSettings.EMAIL_SIZE_LIMIT,
+                    PluginSettings.EMAIL_MINIMUM_HEADER_LENGTH,
+                    PluginSettings.MAX_CONNECTIONS,
+                    PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
+                    PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
+                    PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.ALLOWED_CONFIG_TYPES,
+                    PluginSettings.TOOLTIP_SUPPORT,
+                    PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
+                    PluginSettings.ALERTING_HOST_DENY_LIST,
+                    PluginSettings.HOST_DENY_LIST,
+                    PluginSettings.ENABLE_EMAIL_HTML_SANITIZATION,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_ALLOW_LIST,
+                    PluginSettings.EMAIL_HTML_SANITIZATION_DENY_LIST
+                )
+            )
+        )
+        PluginSettings.addSettingsUpdateConsumer(clusterService)
+        Assertions.assertEquals(
+            true,
+            PluginSettings.enableEmailHtmlSanitization
+        )
+        Assertions.assertEquals(
+            listOf("blocks_group", "links_group"),
+            PluginSettings.emailHtmlSanitizationAllowList
+        )
+        Assertions.assertEquals(
+            listOf("h1", "h2"),
+            PluginSettings.emailHtmlSanitizationDenyList
+        )
+
+        nodeSettings = Settings.builder()
+            .put(enableHtmlSanitizationKey, false)
+            .build()
+
+        whenever(clusterService.settings).thenReturn(nodeSettings)
+        PluginSettings.addSettingsUpdateConsumer(clusterService)
+        Assertions.assertEquals(
+            false,
+            PluginSettings.enableEmailHtmlSanitization
+        )
+
+        nodeSettings = Settings.builder()
+            .put(enableHtmlSanitizationKey, true)
+            .putList(htmlSanitizationAllowListKey, emptyList())
+            .putList(htmlSanitizationDenyListKey, emptyList())
+            .build()
+
+        whenever(clusterService.settings).thenReturn(nodeSettings)
+        PluginSettings.addSettingsUpdateConsumer(clusterService)
+        Assertions.assertEquals(
+            true,
+            PluginSettings.enableEmailHtmlSanitization
+        )
+        Assertions.assertEquals(
+            emptyList<String>(),
+            PluginSettings.emailHtmlSanitizationAllowList
+        )
+        Assertions.assertEquals(
+            emptyList<String>(),
+            PluginSettings.emailHtmlSanitizationDenyList
         )
     }
 }


### PR DESCRIPTION
### Description
The main change of this PR is to add html sanitization enhancement for html format email message, there are three main settings for this enhancement:

- opensearch.notifications.core.email.enable_html_sanitization, defaults to true
- opensearch.notifications.core.email.html_sanitization_allow_list, defaults to ["blocks_group", "formatting_group", "images_group", "links_group", "styles_group", "tables_group"]
- opensearch.notifications.core.email.html_sanitization_deny_list, defaults to []

when `enable_html_sanitization` is set to true, when sending a email with html format, the content of the email will be sanitized by the html sanitizer according to `html_sanitization_allow_list` and `html_sanitization_deny_list`, notice that `html_sanitization_deny_list` only takes effect when `html_sanitization_allow_list` is not empty.

### Issues Resolved
[[List any issues this PR will resolve]](https://github.com/opensearch-project/notifications/issues/586)

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
