### PR TITLE
Add httpcore5-h2 dependency for upgrading httpcore to 5.2.2

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+    implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"


### PR DESCRIPTION
### Description
Add httpcore5-h2 dependency for [upgrading httpcore version to 5.2.2](https://github.com/opensearch-project/OpenSearch/issues/8434)



[TlsConfig.java](https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/config/TlsConfig.java#L42) is using [HttpVersionPolicy](https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/config/TlsConfig.java#L215) which exists in `httpcore5-h2` jar file

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
