### PR TITLE
Refactor XContentType to mediaType

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -265,7 +265,7 @@ testClusters.integTest {
 }
 
 // Always be minimumCompatibilityVersion of current opensearch version(3.0.0)
-def bwcVersionShort = "2.9.0"
+def bwcVersionShort = "2.10.0"
 def bwcVersion = bwcVersionShort + ".0"
 def bwcOpenSearchVesion= bwcVersionShort + "-SNAPSHOT"
 def bwcPluginVersion = bwcVersion + "-SNAPSHOT"

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -17,12 +17,12 @@ import org.opensearch.client.RestClient
 import org.opensearch.client.WarningsHandler
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.rest.SecureRestClientBuilder
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.DeprecationHandler
+import org.opensearch.core.xcontent.MediaType
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.NotificationPlugin
 import org.opensearch.rest.RestRequest
@@ -67,7 +67,7 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
 
         val pluginIndices = listOf(".opensearch-notifications-config")
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
-        val xContentType = XContentType.fromMediaType(response.entity.contentType)
+        val xContentType = MediaType.fromMediaType(response.entity.contentType)
         xContentType.xContent().createParser(
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION,


### PR DESCRIPTION
### Description
1. update to fix compile issue for refactoring XContentType to mediaType in core
2. bump bwc version to 2.10.0
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/8636

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
