### PR TITLE
Fix integration test failure by allowing direct access to system index warning

### DIFF
--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/PluginRestTestCase.kt
@@ -372,10 +372,21 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
     }
 
     protected fun getCurrentMappingsSchemaVersion(): Int {
-        val indexName = ".opensearch-notifications-config"
-        val getMappingRequest = Request(RestRequest.Method.GET.name, "$indexName/_mappings")
+        val getMappingRequest = Request(RestRequest.Method.GET.name, "${NotificationConfigIndex.INDEX_NAME}/_mappings")
+        val requestOptions = RequestOptions.DEFAULT.toBuilder()
+        // Allow direct access to system index warning
+        requestOptions.setWarningsHandler { warnings: List<String> ->
+            if (warnings.isEmpty()) {
+                return@setWarningsHandler false
+            } else if (warnings.size > 1) {
+                return@setWarningsHandler true
+            } else {
+                return@setWarningsHandler !warnings[0].startsWith("this request accesses system indices:")
+            }
+        }
+        getMappingRequest.setOptions(requestOptions)
         val response = executeRequest(getMappingRequest, RestStatus.OK.status, client())
-        val mappingsObject = response.get(indexName).asJsonObject.get("mappings").asJsonObject
+        val mappingsObject = response.get(NotificationConfigIndex.INDEX_NAME).asJsonObject.get("mappings").asJsonObject
         return mappingsObject.get(NotificationConfigIndex._META)?.asJsonObject?.get(NotificationConfigIndex.SCHEMA_VERSION)?.asInt
             ?: NotificationConfigIndex.DEFAULT_SCHEMA_VERSION
     }
@@ -383,7 +394,7 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
     // only refresh the notification config index to avoid too many warnings
     @Throws(IOException::class)
     override fun refreshAllIndices() {
-        val refreshRequest = Request("POST", NotificationConfigIndex.INDEX_NAME + "/_refresh")
+        val refreshRequest = Request("POST", "${NotificationConfigIndex.INDEX_NAME}/_refresh")
         val requestOptions = RequestOptions.DEFAULT.toBuilder()
         // Allow direct access to system index warning
         requestOptions.setWarningsHandler { warnings: List<String> ->


### PR DESCRIPTION
### Description
Fix the integration test failure of `org.opensearch.integtest.config.ChimeNotificationConfigCrudIT` which throws `org.opensearch.client.WarningFailureException` when refreshing all the indices in the test cluster, the change of this PR is that only refresh the system index `.opensearch-notification-config` in this plugin and allow the warning when refreshing the index.

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/783

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
