### PR TITLE
Improve security plugin enabling check

### DIFF
--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -79,10 +79,10 @@ jobs:
       - name: Run Notification Test for security enabled test cases
         if: env.imagePresent == 'true'
         run: |
-          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
-          echo $cluster_running
-          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
-          echo $security
+          container_id=`docker ps -q`
+          plugins=`docker exec $container_id /usr/share/opensearch/bin/opensearch-plugin list`
+          echo "plugins: $plugins" 
+          security=`echo $plugins | grep opensearch-security | wc -l`
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"


### PR DESCRIPTION
### Description
Improve security plugin enabling check for security workflow.

before the change
```
Run cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
  cluster_running=`curl -XGET https://localhost:9[2](https://github.com/opensearch-project/notifications/actions/runs/6528200744/job/17724054412#step:7:2)00/_cat/plugins -u admin:admin --insecure`
  echo $cluster_running
  security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
  echo $security
  if [ $security -gt 0 ]
  then
    echo "Security plugin is available"
    cd notifications
    ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dhttps=true -Duser=admin -Dpassword=admin
  else
    echo "Security plugin is NOT available skipping this run as tests without security have already been run"
    exit 1
  fi
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.20-1/x64
    imagePresent: true
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: ([3](https://github.com/opensearch-project/notifications/actions/runs/6528200744/job/17724054412#step:7:3)[5](https://github.com/opensearch-project/notifications/actions/runs/6528200744/job/17724054412#step:7:5)) error:0A000[10](https://github.com/opensearch-project/notifications/actions/runs/6528200744/job/17724054412#step:7:10)B:SSL routines::wrong version number
Error: Process completed with exit code 35.

```

after the change, security workflow log will look like below 
```
Run container_id=`docker ps -q`
  container_id=`docker ps -q`
  plugins=`docker exec $container_id /usr/share/opensearch/bin/opensearch-plugin list`
  echo "plugins: $plugins" 
  security=`echo $plugins | grep opensearch-security | wc -l`
  if [ $security -gt 0 ]
  then
    echo "Security plugin is available"
    cd notifications
    ./gradlew integTest -Dtests.rest.cluster=localhost:9[2](https://github.com/Hailong-am/notifications/actions/runs/6528580234/job/17724967600#step:7:2)00 -Dtests.cluster=localhost:9200 -Dtests.clustername=docker-cluster -Dhttps=true -Duser=admin -Dpassword=admin
  else
    echo "Security plugin is NOT available skipping this run as tests without security have already been run"
    exit 1
  fi
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.20-1/x6[4](https://github.com/Hailong-am/notifications/actions/runs/6528580234/job/17724967600#step:7:4)
    imagePresent: true
plugins: opensearch-notifications
opensearch-notifications-core
Security plugin is NOT available skipping this run as tests without security have already been run
```

### Issues Resolved
#727 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
