### PR TITLE
Update dependency org.json:json to v20231013

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     } // ${kotlin_version} does not work for coroutines
     implementation "${group}:common-utils:${common_utils_version}"
     // TODO: change compile to implementation when the _local/stats API is supported
-    compileOnly "org.json:json:20230227"
+    compileOnly "org.json:json:20231013"
     compileOnly "com.github.wnameless.json:json-flattener:0.13.0"
     // TODO: uncomment when the _local/stats API is supported
     // implementation "com.github.wnameless.json:json-base:2.0.0"


### PR DESCRIPTION
### Description
The version of the dependency org.json:json is v20230227 which contains a security issue, we need to update it to the latest version.

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/794

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
