### PR TITLE
Re-enable detekt

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -38,16 +38,14 @@ buildscript {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-// TODO: enable detekt only when snakeyaml vulnerability is fixed
-//        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.7"
     }
 }
 
 apply plugin: 'base'
 apply plugin: 'jacoco'
-// TODO: enable detekt only when snakeyaml vulnerability is fixed
-//apply plugin: 'io.gitlab.arturbosch.detekt'
+apply plugin: 'io.gitlab.arturbosch.detekt'
 apply from: 'build-tools/merged-coverage.gradle'
 
 allprojects {
@@ -100,12 +98,11 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
 }
 
-// TODO: enable detekt only when snakeyaml vulnerability is fixed
-//detekt {
-//    config = files("detekt.yml")
-//    buildUponDefaultConfig = true
-//    parallel = true
-//}
+detekt {
+    config = files("detekt.yml")
+    buildUponDefaultConfig = true
+    parallel = true
+}
 
 check.dependsOn ktlint
 


### PR DESCRIPTION
Now that detekt no longer depends on a vulnerable version of snakeyaml, it can be safely re-enabled.

### Description
Undid #528 

### Issues Resolved
Fix #529 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
