### PR TITLE
Add github workflow to auto bump bwc version 

### DIFF
--- a/.github/workflows/bump-bwc.yml
+++ b/.github/workflows/bump-bwc.yml
@@ -1,0 +1,67 @@
+name: Bump bwc version
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+  push:
+    tags:
+      - '*.*.*.*'
+
+permissions: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          #installation_id: 22958780
+          installation_id: 42934585
+
+      - uses: actions/checkout@v4
+      - name: Fetch Tag and Version Information
+        run: |
+          if [ -n ${{ inputs.tag }} ]; then
+            TAG=${{ inputs.tag }}
+          else
+            TAG=$(echo "${GITHUB_REF#refs/*/}")
+          fi
+          CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
+          CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          CURRENT_VERSION_ARRAY[1]=$((CURRENT_VERSION_ARRAY[1]+1))
+          NEXT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Bump bwc version for main branch
+        run: |
+          echo Bumping bwc version to $NEXT_VERSION
+          sed -i "s/def bwcVersionShort = \"$CURRENT_VERSION\"/def bwcVersionShort = \"$NEXT_VERSION\"/g" notifications/notifications/build.gradle
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
+          base: main
+          branch: 'create-pull-request/patch-main'
+          commit-message: Bump bwc version to ${{ env.NEXT_VERSION }}
+          signoff: true
+          delete-branch: true
+          labels: |
+            autocut
+          title: '[AUTO] [main] Bump bwc version to ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and bump bwc version to ${{ env.NEXT_VERSION }}.
+

--- a/.github/workflows/bump-bwc.yml
+++ b/.github/workflows/bump-bwc.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          #installation_id: 22958780
-          installation_id: 42934585
+          installation_id: 22958780
 
       - uses: actions/checkout@v4
       - name: Fetch Tag and Version Information


### PR DESCRIPTION
### Description
Add a new github workflow to bump bwc test version when a new release tag has pushed.

For example, when release tag 2.11.0.0 has pushed, the workflow will help to raise PR to bump bwc version to 2.12.0

It also support manual trigger the workflow by input the tag parameter
![image](https://github.com/opensearch-project/notifications/assets/113890546/4ebd1106-71c5-472f-aeaa-a13529c6d80b)

An example pull request https://github.com/Hailong-am/notifications/pull/7

### Issues Resolved
#798 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
