### PR TITLE
Fix refresh issue

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -182,7 +182,7 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {
         createIndex()
-        val indexRequest = IndexRequest(INDEX_NAME)
+        val indexRequest = IndexRequest(INDEX_NAME).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .source(configDoc.toXContent())
             .create(true)
         if (id != null) {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -291,7 +291,7 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean {
         createIndex()
-        val indexRequest = IndexRequest(INDEX_NAME)
+        val indexRequest = IndexRequest(INDEX_NAME).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .source(notificationConfigDoc.toXContent())
             .create(false)
             .id(id)

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -51,7 +51,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         verifySingleConfigEquals(configId, referenceObject, getConfigResponse)
-        Thread.sleep(100)
+        
 
         // Get all notification config
 
@@ -62,7 +62,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         verifySingleConfigEquals(configId, referenceObject, getAllConfigResponse)
-        Thread.sleep(100)
+        
 
         // Updated notification config object
         val updatedChime = Chime("https://updated.domain.com/updated_chime_url#0987654321")
@@ -93,7 +93,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         Assert.assertEquals(configId, updateResponse.get("config_id").asString)
-        Thread.sleep(1000)
+        
 
         // Get updated chime notification config
 
@@ -104,12 +104,12 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         verifySingleConfigEquals(configId, updatedObject, getUpdatedConfigResponse)
-        Thread.sleep(100)
+        
 
         // Delete chime notification config
         val deleteResponse = deleteConfig(configId)
         Assert.assertEquals("OK", deleteResponse.get("delete_response_list").asJsonObject.get(configId).asString)
-        Thread.sleep(1000)
+        
 
         // Get chime notification config after delete
 
@@ -119,7 +119,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
             "",
             RestStatus.NOT_FOUND.status
         )
-        Thread.sleep(100)
+        
     }
 
     fun `test BAD Request for multiple config data for Chime using REST Client`() {
@@ -179,7 +179,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
         """.trimIndent()
         val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
-        Thread.sleep(1000)
+        
 
         // Update to slack notification config
         val updateRequestJsonString = """
@@ -267,7 +267,7 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
         """.trimIndent()
         val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
-        Thread.sleep(1000)
+        
 
         // update to new webhook URL
         val updateRequestJsonString = """

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/ChimeNotificationConfigCrudIT.kt
@@ -41,7 +41,6 @@ class ChimeNotificationConfigCrudIT : PluginRestTestCase() {
         """.trimIndent()
         val configId = createConfigWithRequestJsonString(createRequestJsonString)
         Assert.assertNotNull(configId)
-        Thread.sleep(1000)
 
         // Get chime notification config
 


### PR DESCRIPTION
### Description
The change of setting the refresh policy to IMMEDIATE ensures that the index is refreshed right away after a create, update, or delete operation on the notification configs. This makes the changes visible in real-time without waiting for the next scheduled refresh. It's beneficial in scenarios where immediate visibility of changes is crucial, such as in real-time applications or testing environments. By making this change, the need for Thread.sleep invocations in integration tests is eliminated, making the tests potentially faster and more reliable.

### Issues Resolved
This PR will resolve the issue regarding the delay in reflecting changes when creating, updating, or deleting notification configurations due to the index not being immediately refreshed. By ensuring an immediate refresh, it enhances real-time visibility of changes, improves user interaction with the notifications API, and optimizes integration testing by removing the need for Thread.sleep invocations to wait for the index to refresh.


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
