### PR TITLE
[Backport 2.x] Re-enable detekt (#796)

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -38,7 +38,7 @@ buildscript {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.7"
     }
 }


### PR DESCRIPTION
Cherry picked from commit 0e55d38cbaa372265e444ca9107b6519b8b75c44

### Description
Bumped version of `io.gitlab.arturbosch.detekt:detekt-gradle-plugin` to `1.23.0`

### Issues Resolved
None

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
