### PR TITLE
[Backport 2.x] Added org.apache.logging.log4j:log4j-slf4j-impl to classpath (#791)

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -142,6 +142,8 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-ses:${aws_version}"
     implementation "com.sun.mail:javax.mail:1.6.2"
     implementation "javax.activation:activation:1.1"
+    implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',


### PR DESCRIPTION
* Added org.apache.logging.log4j:log4j-slf4j-impl to classpath

Signed-off-by: Aniruddh <63553175+Noir01@users.noreply.github.com>
(cherry picked from commit 62b7b4f840e7e224f947f1745da375df6f419b9b)

### Description
Fixes warning message shown when sending test message

### Issues Resolved
fixes #693

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
