### PR TITLE
adding hostname support for notifications deny list

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -10,6 +10,7 @@ import inet.ipaddr.IPAddressString
 import org.apache.hc.client5.http.classic.methods.HttpPatch
 import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
+import org.apache.logging.log4j.LogManager
 import org.opensearch.core.common.Strings
 import java.net.URL
 
@@ -43,6 +44,7 @@ fun isHostInDenylist(urlString: String, hostDenyList: List<String>): Boolean {
             val denyIpStr = IPAddressString(network)
             val denyHostStr = HostName(network)
             if (denyIpStr.contains(ipStr) || denyHostStr.equals(hostStr)) {
+                LogManager.getLogger().error("${url.host} is denied")
                 return true
             }
         }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.notifications.core.utils
 
+import inet.ipaddr.HostName
 import inet.ipaddr.IPAddressString
 import org.apache.hc.client5.http.classic.methods.HttpPatch
 import org.apache.hc.client5.http.classic.methods.HttpPost
@@ -37,9 +38,11 @@ fun isHostInDenylist(urlString: String, hostDenyList: List<String>): Boolean {
     val url = URL(urlString)
     if (url.host != null) {
         val ipStr = IPAddressString(url.host)
+        val hostStr = HostName(url.host)
         for (network in hostDenyList) {
-            val netStr = IPAddressString(network)
-            if (netStr.contains(ipStr)) {
+            val denyIpStr = IPAddressString(network)
+            val denyHostStr = HostName(network)
+            if (denyIpStr.contains(ipStr) || denyHostStr.equals(hostStr)) {
                 return true
             }
         }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
@@ -33,7 +33,7 @@ internal class ValidationHelpersTests {
             "9.9.9.9"
         )
         for (ip in ips) {
-            assertEquals(true, isHostInDenylist("https://$ip", hostDenyList), "for hostname $ip")
+            assertEquals(true, isHostInDenylist("https://$ip", hostDenyList), "address $ip was supposed to be identified as in the deny list, but was not")
         }
     }
 
@@ -41,7 +41,7 @@ internal class ValidationHelpersTests {
     fun `test hosts not in denylist`() {
         val urls = listOf("156.4.77.1", "www.something.com")
         for (url in urls) {
-            assertEquals(false, isHostInDenylist("https://$url", hostDenyList), "for hostname $url")
+            assertEquals(false, isHostInDenylist("https://$url", hostDenyList), "address $url was not supposed to be identified as in the deny list, but was")
         }
     }
 }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.Test
 
 internal class ValidationHelpersTests {
 
-    private val hostDentyList = listOf(
+    private val hostDenyList = listOf(
+        "www.amazon.com",
         "127.0.0.0/8",
         "10.0.0.0/8",
         "172.16.0.0/12",
@@ -20,8 +21,9 @@ internal class ValidationHelpersTests {
     )
 
     @Test
-    fun `test ips in denylist`() {
+    fun `test hosts in denylist`() {
         val ips = listOf(
+            "www.amazon.com",
             "127.0.0.1", // 127.0.0.0/8
             "10.0.0.1", // 10.0.0.0/8
             "10.11.12.13", // 10.0.0.0/8
@@ -31,15 +33,15 @@ internal class ValidationHelpersTests {
             "9.9.9.9"
         )
         for (ip in ips) {
-            assertEquals(true, isHostInDenylist("https://$ip", hostDentyList))
+            assertEquals(true, isHostInDenylist("https://$ip", hostDenyList), "for hostname $ip")
         }
     }
 
     @Test
-    fun `test url in denylist`() {
-        val urls = listOf("https://www.amazon.com", "https://mytest.com", "https://mytest.com")
+    fun `test hosts not in denylist`() {
+        val urls = listOf("156.4.77.1", "www.something.com")
         for (url in urls) {
-            assertEquals(false, isHostInDenylist(url, hostDentyList))
+            assertEquals(false, isHostInDenylist("https://$url", hostDenyList), "for hostname $url")
         }
     }
 }


### PR DESCRIPTION
### Description
Adds support for checking hostnames in a customer's deny list, in addition to the existing functionality of checking IP addresses.

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
