### PR TITLE
Adding max http response string length as a setting, and capping http…

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -148,7 +148,7 @@ class DestinationHttpClient {
     @Throws(IOException::class)
     fun getResponseString(response: CloseableHttpResponse): String {
         val entity: HttpEntity = response.entity ?: return "{}"
-        val responseString = EntityUtils.toString(entity)
+        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseStrLength)
         // DeliveryStatus need statusText must not be empty, convert empty response to {}
         return if (responseString.isNullOrEmpty()) "{}" else responseString
     }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -148,7 +148,7 @@ class DestinationHttpClient {
     @Throws(IOException::class)
     fun getResponseString(response: CloseableHttpResponse): String {
         val entity: HttpEntity = response.entity ?: return "{}"
-        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseStrLength)
+        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseSize / 2) // Java char is 2 bytes
         // DeliveryStatus need statusText must not be empty, convert empty response to {}
         return if (responseString.isNullOrEmpty()) "{}" else responseString
     }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
@@ -82,6 +82,11 @@ internal object PluginSettings {
     private const val SOCKET_TIMEOUT_MILLISECONDS_KEY = "$HTTP_CONNECTION_KEY_PREFIX.socket_timeout"
 
     /**
+     * Setting for maximum string length of HTTP response, allows protection from DoS
+     */
+    private const val MAX_HTTP_RESPONSE_STRING_LENGTH_KEY = "$KEY_PREFIX.max_http_response_string_length"
+
+    /**
      * Legacy setting for list of host deny list in Alerting
      */
     private const val LEGACY_ALERTING_HOST_DENY_LIST_KEY = "opendistro.destination.host.deny_list"
@@ -105,11 +110,6 @@ internal object PluginSettings {
      * Setting to enable tooltip in UI
      */
     private const val TOOLTIP_SUPPORT_KEY = "$KEY_PREFIX.tooltip_support"
-
-    /**
-     * Setting for maximum string length of HTTP response, allows protection from DoS
-     */
-    private const val MAX_HTTP_RESPONSE_STRING_LENGTH_KEY = "$KEY_PREFIX.max_http_response_string_length"
 
     /**
      * Setting to provide cluster name, which is <AWS-account-number:AWS-domain-name> on the managed service

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
@@ -32,6 +32,7 @@ internal class PluginSettingsTests {
     private val httpMaxConnectionPerRouteKey = "$httpKeyPrefix.max_connection_per_route"
     private val httpConnectionTimeoutKey = "$httpKeyPrefix.connection_timeout"
     private val httpSocketTimeoutKey = "$httpKeyPrefix.socket_timeout"
+    private val maxHttpResponseStrLengthKey = "$keyPrefix.max_http_response_string_length"
     private val legacyAlertingHostDenyListKey = "opendistro.destination.host.deny_list"
     private val alertingHostDenyListKey = "plugins.destination.host.deny_list"
     private val httpHostDenyListKey = "$httpKeyPrefix.host_deny_list"
@@ -48,6 +49,7 @@ internal class PluginSettingsTests {
         .put(httpMaxConnectionPerRouteKey, 20)
         .put(httpConnectionTimeoutKey, 5000)
         .put(httpSocketTimeoutKey, 50000)
+        .put(maxHttpResponseStrLengthKey, 25000000)
         .putList(httpHostDenyListKey, emptyList<String>())
         .putList(
             allowedConfigTypeKey,
@@ -91,6 +93,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST
@@ -119,6 +122,10 @@ internal class PluginSettingsTests {
             PluginSettings.socketTimeout.toString()
         )
         Assertions.assertEquals(
+            defaultSettings[maxHttpResponseStrLengthKey],
+            PluginSettings.maxHttpResponseStrLength.toString()
+        )
+        Assertions.assertEquals(
             defaultSettings[allowedConfigTypeKey],
             PluginSettings.allowedConfigTypes.toString()
         )
@@ -145,6 +152,7 @@ internal class PluginSettingsTests {
             .put(httpMaxConnectionPerRouteKey, 100)
             .put(httpConnectionTimeoutKey, 100)
             .put(httpSocketTimeoutKey, 100)
+            .put(maxHttpResponseStrLengthKey, 20000000)
             .putList(httpHostDenyListKey, listOf("sample"))
             .putList(allowedConfigTypeKey, listOf("slack"))
             .put(tooltipSupportKey, false)
@@ -163,6 +171,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST,
@@ -190,6 +199,14 @@ internal class PluginSettingsTests {
         Assertions.assertEquals(
             100,
             clusterService.clusterSettings.get(PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS)
+        )
+        Assertions.assertEquals(
+            100,
+            clusterService.clusterSettings.get(PluginSettings.SOCKET_TIMEOUT_MILLISECONDS)
+        )
+        Assertions.assertEquals(
+            20000000,
+            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH)
         )
         Assertions.assertEquals(
             listOf("sample"),
@@ -224,6 +241,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST,
@@ -251,6 +269,14 @@ internal class PluginSettingsTests {
         Assertions.assertEquals(
             defaultSettings[httpConnectionTimeoutKey],
             clusterService.clusterSettings.get(PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS).toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[httpSocketTimeoutKey],
+            clusterService.clusterSettings.get(PluginSettings.SOCKET_TIMEOUT_MILLISECONDS).toString()
+        )
+        Assertions.assertEquals(
+            defaultSettings[maxHttpResponseStrLengthKey],
+            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH).toString()
         )
         Assertions.assertEquals(
             defaultSettings[httpHostDenyListKey],
@@ -290,6 +316,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
@@ -325,6 +352,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
@@ -359,6 +387,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
+                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/settings/PluginSettingsTests.kt
@@ -16,6 +16,7 @@ import org.opensearch.cluster.ClusterName
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
 import org.opensearch.common.settings.Settings
+import org.opensearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH
 import org.opensearch.notifications.core.NotificationCorePlugin
 import org.opensearch.notifications.core.setting.PluginSettings
 
@@ -32,7 +33,7 @@ internal class PluginSettingsTests {
     private val httpMaxConnectionPerRouteKey = "$httpKeyPrefix.max_connection_per_route"
     private val httpConnectionTimeoutKey = "$httpKeyPrefix.connection_timeout"
     private val httpSocketTimeoutKey = "$httpKeyPrefix.socket_timeout"
-    private val maxHttpResponseStrLengthKey = "$keyPrefix.max_http_response_string_length"
+    private val maxHttpResponseSizeKey = "$keyPrefix.max_http_response_size"
     private val legacyAlertingHostDenyListKey = "opendistro.destination.host.deny_list"
     private val alertingHostDenyListKey = "plugins.destination.host.deny_list"
     private val httpHostDenyListKey = "$httpKeyPrefix.host_deny_list"
@@ -49,7 +50,7 @@ internal class PluginSettingsTests {
         .put(httpMaxConnectionPerRouteKey, 20)
         .put(httpConnectionTimeoutKey, 5000)
         .put(httpSocketTimeoutKey, 50000)
-        .put(maxHttpResponseStrLengthKey, 25000000)
+        .put(maxHttpResponseSizeKey, SETTING_HTTP_MAX_CONTENT_LENGTH.getDefault(Settings.EMPTY).getBytes().toInt())
         .putList(httpHostDenyListKey, emptyList<String>())
         .putList(
             allowedConfigTypeKey,
@@ -93,7 +94,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST
@@ -122,8 +123,8 @@ internal class PluginSettingsTests {
             PluginSettings.socketTimeout.toString()
         )
         Assertions.assertEquals(
-            defaultSettings[maxHttpResponseStrLengthKey],
-            PluginSettings.maxHttpResponseStrLength.toString()
+            defaultSettings[maxHttpResponseSizeKey],
+            PluginSettings.maxHttpResponseSize.toString()
         )
         Assertions.assertEquals(
             defaultSettings[allowedConfigTypeKey],
@@ -152,7 +153,7 @@ internal class PluginSettingsTests {
             .put(httpMaxConnectionPerRouteKey, 100)
             .put(httpConnectionTimeoutKey, 100)
             .put(httpSocketTimeoutKey, 100)
-            .put(maxHttpResponseStrLengthKey, 20000000)
+            .put(maxHttpResponseSizeKey, 20000000)
             .putList(httpHostDenyListKey, listOf("sample"))
             .putList(allowedConfigTypeKey, listOf("slack"))
             .put(tooltipSupportKey, false)
@@ -171,7 +172,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST,
@@ -206,7 +207,7 @@ internal class PluginSettingsTests {
         )
         Assertions.assertEquals(
             20000000,
-            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH)
+            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_SIZE)
         )
         Assertions.assertEquals(
             listOf("sample"),
@@ -241,7 +242,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.HOST_DENY_LIST,
@@ -275,8 +276,8 @@ internal class PluginSettingsTests {
             clusterService.clusterSettings.get(PluginSettings.SOCKET_TIMEOUT_MILLISECONDS).toString()
         )
         Assertions.assertEquals(
-            defaultSettings[maxHttpResponseStrLengthKey],
-            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH).toString()
+            defaultSettings[maxHttpResponseSizeKey],
+            clusterService.clusterSettings.get(PluginSettings.MAX_HTTP_RESPONSE_SIZE).toString()
         )
         Assertions.assertEquals(
             defaultSettings[httpHostDenyListKey],
@@ -316,7 +317,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
@@ -352,7 +353,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,
@@ -387,7 +388,7 @@ internal class PluginSettingsTests {
                     PluginSettings.MAX_CONNECTIONS_PER_ROUTE,
                     PluginSettings.CONNECTION_TIMEOUT_MILLISECONDS,
                     PluginSettings.SOCKET_TIMEOUT_MILLISECONDS,
-                    PluginSettings.MAX_HTTP_RESPONSE_STRING_LENGTH,
+                    PluginSettings.MAX_HTTP_RESPONSE_SIZE,
                     PluginSettings.ALLOWED_CONFIG_TYPES,
                     PluginSettings.TOOLTIP_SUPPORT,
                     PluginSettings.LEGACY_ALERTING_HOST_DENY_LIST,


### PR DESCRIPTION
Adding max http response string length as a setting, and capping http response string based on that setting

### Description
Adding a cap to the length of HTTP response strings.

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
