### PR TITLE
Doing max HTTP response size string truncation manually

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -148,7 +148,10 @@ class DestinationHttpClient {
     @Throws(IOException::class)
     fun getResponseString(response: CloseableHttpResponse): String {
         val entity: HttpEntity = response.entity ?: return "{}"
-        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseSize / 2) // Java char is 2 bytes
+        var responseString = EntityUtils.toString(entity)
+        if (responseString.length > (PluginSettings.maxHttpResponseSize / 2)) { // Java char is 2 bytes
+            responseString = responseString.substring(0, PluginSettings.maxHttpResponseSize / 2)
+        }
         // DeliveryStatus need statusText must not be empty, convert empty response to {}
         return if (responseString.isNullOrEmpty()) "{}" else responseString
     }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/setting/PluginSettings.kt
@@ -155,7 +155,7 @@ internal object PluginSettings {
     /**
      * Default maximum HTTP response string length
      */
-    private val DEFAULT_MAX_HTTP_RESPONSE_SIZE = SETTING_HTTP_MAX_CONTENT_LENGTH.getDefault(Settings.EMPTY).getBytes().toInt()
+    private val DEFAULT_MAX_HTTP_RESPONSE_SIZE = SETTING_HTTP_MAX_CONTENT_LENGTH.getDefault(Settings.EMPTY).bytes.toInt()
 
     /**
      * Default email header length. minimum value from 100 reference emails

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -276,6 +276,7 @@ configurations {
 }
 
 dependencies {
+    testImplementation project(path: ':opensearch-notifications-core')
     opensearchPlugin "org.opensearch.plugin:opensearch-notifications-core:${bwcPluginVersion}@zip"
     opensearchPlugin "org.opensearch.plugin:notifications:${bwcPluginVersion}@zip"
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/MaxHTTPResponseSizeIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/MaxHTTPResponseSizeIT.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integtest
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.notifications.core.NotificationCoreImpl
+import org.opensearch.notifications.spi.model.DestinationMessageResponse
+import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.spi.model.destination.CustomWebhookDestination
+import org.opensearch.rest.RestRequest
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+internal class MaxHTTPResponseSizeIT : PluginRestTestCase() {
+    fun `test HTTP response has truncated size`() {
+        // update max http response size setting
+        val updateSettingJsonString = """
+        {
+            "persistent": {
+                "opensearch.notifications.core.max_http_response_size": "10"
+            }
+        }
+        """.trimIndent()
+
+        val updateSettingsResponse = executeRequest(
+            RestRequest.Method.PUT.name,
+            "/_cluster/settings",
+            updateSettingJsonString,
+            RestStatus.OK.status
+        )
+        Assert.assertNotNull(updateSettingsResponse)
+        logger.info("update settings response: $updateSettingsResponse")
+        Thread.sleep(1000)
+
+        val title = "test custom webhook"
+        val messageText = "{\"Content\":\"sample message\"}"
+        val url = "http://${server.address.hostString}:${server.address.port}/webhook"
+
+        val destination = CustomWebhookDestination(url, mapOf("headerKey" to "headerValue"), "POST")
+        val message = MessageContent(title, messageText)
+
+        val actualCustomWebhookResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "ref")
+
+        logger.info("response: ${actualCustomWebhookResponse.statusText}")
+    }
+
+    companion object {
+        private lateinit var server: HttpServer
+
+        @JvmStatic
+        @BeforeClass
+        fun setupWebhook() {
+            server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0)
+
+            server.createContext("/webhook") {
+                val response = "This is a longer than usual response that should be truncated"
+                it.sendResponseHeaders(200, response.length.toLong())
+                val os = it.responseBody
+                os.write(response.toByteArray())
+                os.close()
+            }
+
+            server.start()
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun stopMockServer() {
+            server.stop(1)
+        }
+    }
+}


### PR DESCRIPTION
### Description
Instead of leaving it to `apache.hc.core5`'s `toString()` to truncate the HTTP response for us, we do it manually to support backports, since previous versions don't use `apache.hc.core5`.

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
