### PR TITLE
doing HTTP response string truncation manually to support backports

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -148,7 +148,10 @@ class DestinationHttpClient {
     @Throws(IOException::class)
     fun getResponseString(response: CloseableHttpResponse): String {
         val entity: HttpEntity = response.entity ?: return "{}"
-        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseSize / 2) // Java char is 2 bytes
+        var responseString = EntityUtils.toString(entity)
+        if (responseString.length > (PluginSettings.maxHttpResponseSize / 2)) { // Java char is 2 bytes
+            responseString = responseString.substring(0, PluginSettings.maxHttpResponseSize / 2)
+        }
         // DeliveryStatus need statusText must not be empty, convert empty response to {}
         return if (responseString.isNullOrEmpty()) "{}" else responseString
     }


### PR DESCRIPTION
### Description
Instead of leaving HTTP response string truncation to `apache.hc.core5`'s toString(), which comes with a max string length argument, we do the truncation manually to support backports since previous versions don't use `apache.hc.core5`.

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
