### PR TITLE
Upgrade AWS version for SDKs to 1.12.687

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.8.21")
         junit_version = System.getProperty("junit.version", "5.7.2")
-        aws_version = System.getProperty("aws.version", "1.12.48")
+        aws_version = System.getProperty("aws.version", "1.12.687")
     }
 
     repositories {


### PR DESCRIPTION
### Description
Upgrade AWS version for SDKs to 1.12.687

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Security tests are still failing if we revert this change. Tested on another test PR: https://github.com/AWSHurneyt/notifications/pull/2