### PR TITLE
replacing spi.utils isHostInDenyList with core.utils isHostInDenyList

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -20,7 +20,7 @@ fun validateUrl(urlString: String) {
 }
 
 fun validateUrlHost(urlString: String, hostDenyList: List<String>) {
-    require(!org.opensearch.notifications.spi.utils.isHostInDenylist(urlString, hostDenyList)) {
+    require(!isHostInDenylist(urlString, hostDenyList)) {
         "Host of url is denied, based on plugin setting [notification.core.http.host_deny_list]"
     }
 }


### PR DESCRIPTION
### Description
Testing: on local cluster, added a sample hostname to the deny list, then created channel with custom webhook option to a URL that sends to the denied hostname and received following error:
```
[status_exception] {"event_status_list": [{"config_id":"-q47444BQsqriBBcpim5","config_type":"webhook","config_name":"temp-test","email_recipient_status":[],"delivery_status":{"status_code":"400","status_text":"Webhook message creation failed with status:Host of url is denied, based on plugin setting [notification.core.http.host_deny_list]"}}]}
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
