### PR TITLE
upgrade upload-artifact to version 4

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -63,13 +63,13 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts for notifications plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: notifications-plugin-${{ matrix.os }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: notifications-core-plugin-${{ matrix.os }}
           path: notifications-build/notifications-core
@@ -129,13 +129,13 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts for notifications plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: notifications-plugin-${{ matrix.os }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: notifications-core-plugin-${{ matrix.os }}
           path: notifications-build/notifications-core

--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -7,6 +7,9 @@ name: Test and Build Notifications
 
 on: [push, pull_request]
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -65,13 +68,13 @@ jobs:
       - name: Upload Artifacts for notifications plugin
         uses: actions/upload-artifact@v4
         with:
-          name: notifications-plugin-${{ matrix.os }}
+          name: notifications-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
         uses: actions/upload-artifact@v4
         with:
-          name: notifications-core-plugin-${{ matrix.os }}
+          name: notifications-core-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: notifications-build/notifications-core
 
   build-windows-macos:
@@ -131,11 +134,11 @@ jobs:
       - name: Upload Artifacts for notifications plugin
         uses: actions/upload-artifact@v4
         with:
-          name: notifications-plugin-${{ matrix.os }}
+          name: notifications-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
         uses: actions/upload-artifact@v4
         with:
-          name: notifications-core-plugin-${{ matrix.os }}
+          name: notifications-core-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: notifications-build/notifications-core

--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -7,6 +7,9 @@ name: Security Test and Build Notifications
 
 on: [push, pull_request]
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
### Description
upgrade upload-artifact to version 4, as v1 and v2 are deprecated.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
