### PR TITLE
Upgrade upload-artifact to v3 and bump version to 2.17.1

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -63,13 +63,13 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts for notifications plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: notifications-plugin-${{ matrix.os }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: notifications-core-plugin-${{ matrix.os }}
           path: notifications-build/notifications-core
@@ -129,13 +129,13 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts for notifications plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: notifications-plugin-${{ matrix.os }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: notifications-core-plugin-${{ matrix.os }}
           path: notifications-build/notifications-core

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.17.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.17.1-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.3.0-SNAPSHOT -> 2.3.0.0-SNAPSHOT


### PR DESCRIPTION
### Description
Upgrade upload-artifact to v3 to fix the CI and bump version to 2.17.1

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
