### PR TITLE
Resovle host to all ips and check against the deny list

### DIFF
--- a/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
+++ b/notifications/core-spi/src/test/kotlin/org/opensearch/notifications/spi/utils/ValidationHelpersTests.kt
@@ -51,13 +51,21 @@ internal class ValidationHelpersTests {
 
     @Test
     fun `test hostname gets resolved to ip for denylist`() {
-        val invalidHost = "invalid.com"
+        val expectedAddressesForInvalidHost = arrayOf(
+            InetAddress.getByName("174.120.0.0"),
+            InetAddress.getByName("10.0.0.1")
+        )
+        val expectedAddressesForValidHost = arrayOf(
+            InetAddress.getByName("174.12.0.0")
+        )
+
         mockkStatic(InetAddress::class)
-        every { InetAddress.getByName(invalidHost).hostAddress } returns "10.0.0.1" // 10.0.0.0/8
+        val invalidHost = "invalid.com"
+        every { InetAddress.getAllByName(invalidHost) } returns expectedAddressesForInvalidHost
         assertEquals(true, isHostInDenylist("https://$invalidHost", hostDenyList))
 
         val validHost = "valid.com"
-        every { InetAddress.getByName(validHost).hostAddress } returns "174.12.0.0"
+        every { InetAddress.getAllByName(validHost) } returns expectedAddressesForValidHost
         assertEquals(false, isHostInDenylist("https://$validHost", hostDenyList))
     }
 

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -24,9 +24,11 @@ fun validateUrl(urlString: String) {
 
 fun validateUrlHost(urlString: String, hostDenyList: List<String>) {
     val url = URL(urlString)
-    require(org.opensearch.notifications.spi.utils.getResolvedIps(url.host).isNotEmpty()) {
-        "Host could not be resolved to a valid Ip address"
+
+    if (org.opensearch.notifications.spi.utils.getResolvedIps(url.host).isEmpty()) {
+        throw UnknownHostException("Host could not be resolved to a valid Ip address")
     }
+
     require(!org.opensearch.notifications.spi.utils.isHostInDenylist(urlString, hostDenyList)) {
         "Host of url is denied, based on plugin setting [notification.core.http.host_deny_list]"
     }

--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/utils/ValidationHelpers.kt
@@ -12,7 +12,10 @@ import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
 import org.apache.logging.log4j.LogManager
 import org.opensearch.core.common.Strings
+import java.lang.Exception
+import java.net.InetAddress
 import java.net.URL
+import java.net.UnknownHostException
 
 fun validateUrl(urlString: String) {
     require(!Strings.isNullOrEmpty(urlString)) { "url is null or empty" }
@@ -20,7 +23,11 @@ fun validateUrl(urlString: String) {
 }
 
 fun validateUrlHost(urlString: String, hostDenyList: List<String>) {
-    require(!isHostInDenylist(urlString, hostDenyList)) {
+    val url = URL(urlString)
+    require(org.opensearch.notifications.spi.utils.getResolvedIps(url.host).isNotEmpty()) {
+        "Host could not be resolved to a valid Ip address"
+    }
+    require(!org.opensearch.notifications.spi.utils.isHostInDenylist(urlString, hostDenyList)) {
         "Host of url is denied, based on plugin setting [notification.core.http.host_deny_list]"
     }
 }
@@ -35,18 +42,39 @@ fun isValidUrl(urlString: String): Boolean {
     return ("https" == url.protocol || "http" == url.protocol) // Support only http/https, other protocols not supported
 }
 
+@Deprecated("This function is not maintained, use org.opensearch.notifications.spi.utils.isHostInDenylist instead.")
 fun isHostInDenylist(urlString: String, hostDenyList: List<String>): Boolean {
     val url = URL(urlString)
     if (url.host != null) {
-        val ipStr = IPAddressString(url.host)
-        val hostStr = HostName(url.host)
-        for (network in hostDenyList) {
-            val denyIpStr = IPAddressString(network)
-            val denyHostStr = HostName(network)
-            if (denyIpStr.contains(ipStr) || denyHostStr.equals(hostStr)) {
-                LogManager.getLogger().error("${url.host} is denied")
-                return true
+        try {
+            val resolvedIps = InetAddress.getAllByName(url.host)
+            val resolvedIpStrings = resolvedIps.map { inetAddress -> IPAddressString(inetAddress.hostAddress) }
+            val hostStr = HostName(url.host)
+
+            for (network in hostDenyList) {
+                val denyIpStr = IPAddressString(network)
+                val denyHostStr = HostName(network)
+                val hostInDenyList = denyHostStr.equals(hostStr)
+                var ipInDenyList = false
+
+                for (ipStr in resolvedIpStrings) {
+                    if (denyIpStr.contains(ipStr)) {
+                        ipInDenyList = true
+                        break
+                    }
+                }
+
+                if (hostInDenyList || ipInDenyList) {
+                    LogManager.getLogger().error("${url.host} is denied")
+                    return true
+                }
             }
+        } catch (e: UnknownHostException) {
+            LogManager.getLogger().error("Error checking denylist: Unknown host")
+            return false
+        } catch (e: Exception) {
+            LogManager.getLogger().error("Error checking denylist: ${e.message}", e)
+            return false
         }
     }
 

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/ChimeDestinationTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.notifications.core.destinations
 
+import inet.ipaddr.IPAddressString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -50,6 +51,7 @@ internal class ChimeDestinationTests {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
         every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
+        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns listOf(IPAddressString("174.0.0.0"))
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/CustomWebhookDestinationTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.notifications.core.destinations
 
+import inet.ipaddr.IPAddressString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -62,6 +63,7 @@ internal class CustomWebhookDestinationTests {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
         every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
+        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns listOf(IPAddressString("174.0.0.0"))
     }
 
     @ParameterizedTest(name = "method {0} should return corresponding type of Http request object {1}")

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/MicrosoftTeamsDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/MicrosoftTeamsDestinationTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.notifications.core.destinations
 
+import inet.ipaddr.IPAddressString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -52,6 +53,7 @@ internal class MicrosoftTeamsDestinationTests {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
         every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
+        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns listOf(IPAddressString("174.0.0.0"))
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/SlackDestinationTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.notifications.core.destinations
 
+import inet.ipaddr.IPAddressString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -52,6 +53,7 @@ internal class SlackDestinationTests {
         // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
         every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
+        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns listOf(IPAddressString("174.0.0.0"))
     }
 
     @Test

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/utils/ValidationHelpersTests.kt
@@ -5,8 +5,11 @@
 
 package org.opensearch.notifications.core.utils
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.net.InetAddress
 
 internal class ValidationHelpersTests {
 
@@ -43,5 +46,25 @@ internal class ValidationHelpersTests {
         for (url in urls) {
             assertEquals(false, isHostInDenylist("https://$url", hostDenyList), "address $url was not supposed to be identified as in the deny list, but was")
         }
+    }
+
+    @Test
+    fun `test hostname gets resolved to ip for denylist`() {
+        val expectedAddressesForInvalidHost = arrayOf(
+            InetAddress.getByName("174.120.0.0"),
+            InetAddress.getByName("10.0.0.1")
+        )
+        val expectedAddressesForValidHost = arrayOf(
+            InetAddress.getByName("174.12.0.0")
+        )
+
+        mockkStatic(InetAddress::class)
+        val invalidHost = "invalid.com"
+        every { InetAddress.getAllByName(invalidHost) } returns expectedAddressesForInvalidHost
+        assertEquals(true, isHostInDenylist("https://$invalidHost", hostDenyList))
+
+        val validHost = "valid.com"
+        every { InetAddress.getAllByName(validHost) } returns expectedAddressesForValidHost
+        assertEquals(false, isHostInDenylist("https://$validHost", hostDenyList))
     }
 }


### PR DESCRIPTION
### Description
Currently there are two issues with the deny list check in custom webhooks
- We are not resolving the host to the IP address before matching
- We match only for the first IP the host resolves to

This PR fixes both the issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
