### PR TITLE
Set notifications plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 17
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     # Job name
     name: Build Notifications with JDK ${{ matrix.java }} on linux
@@ -85,7 +85,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest

--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     runs-on: ubuntu-latest
 

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -21,9 +21,10 @@ buildscript {
         }
         opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        kotlin_version = System.getProperty("kotlin.version", "1.8.21")
+        kotlin_version = System.getProperty("kotlin.version", "1.9.25")
         junit_version = System.getProperty("junit.version", "5.7.2")
         aws_version = System.getProperty("aws.version", "1.12.687")
+        asm_version = "9.7"
     }
 
     repositories {
@@ -40,6 +41,16 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.11"
+    }
+    
+     configurations {
+        classpath {
+            resolutionStrategy {
+                //in order to handle jackson's higher release version in shadow, this needs to be upgraded to latest
+                force(group: "org.ow2.asm", name: "asm", version: asm_version)
+                force(group: "org.ow2.asm", name: "asm-commons", version: asm_version)
+            }
+        }
     }
 }
 
@@ -58,11 +69,18 @@ allprojects {
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     }
     group = "org.opensearch"
+
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "11"
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     plugins.withId('org.jetbrains.kotlin.jvm') {
-        compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = "11"
+        compileJava.sourceCompatibility = JavaVersion.VERSION_21
+        compileJava.targetCompatibility = JavaVersion.VERSION_21
+        compileTestJava.sourceCompatibility = JavaVersion.VERSION_21
+        compileTestJava.targetCompatibility = JavaVersion.VERSION_21
+        compileKotlin.kotlinOptions.jvmTarget = "21"
+        compileTestKotlin.kotlinOptions.jvmTarget = "21"
         compileKotlin.dependsOn ktlint
     }
 }

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         kotlin_version = System.getProperty("kotlin.version", "1.9.25")
         junit_version = System.getProperty("junit.version", "5.7.2")
         aws_version = System.getProperty("aws.version", "1.12.687")
-        asm_version = "9.7"
+        asm_version = System.getProperty("asm.version", "9.7")
     }
 
     repositories {

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -6,7 +6,7 @@
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'io.github.goooler.shadow' version "8.1.7"
     id 'jacoco'
     id 'maven-publish'
     id 'signing'


### PR DESCRIPTION
### Description
Set notifications plugin 3.0.0 baseline JDK version to JDK-21

### Related Issues
Closes https://github.com/opensearch-project/notifications/issues/924
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
