### PR TITLE
Add JDK-23 to the build matrix

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [21]
+        java: [21, 23]
 
     # Job name
     name: Build Notifications with JDK ${{ matrix.java }} on linux
@@ -85,7 +85,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [21]
+        java: [21, 23]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest

--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [21]
+        java: [21, 23]
 
     runs-on: ubuntu-latest
 

--- a/notifications/build-tools/merged-coverage.gradle
+++ b/notifications/build-tools/merged-coverage.gradle
@@ -5,7 +5,7 @@
 
 allprojects {
     plugins.withId('jacoco') {
-        jacoco.toolVersion = '0.8.11'
+        jacoco.toolVersion = '0.8.12'
         // For some reason this dependency isn't getting setup automatically by the jacoco plugin
         tasks.withType(JacocoReport) { 
             dependsOn tasks.withType(Test)

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
-        classpath "org.jacoco:org.jacoco.agent:0.8.11"
+        classpath "org.jacoco:org.jacoco.agent:0.8.12"
     }
     
      configurations {

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -149,7 +149,7 @@ dependencies {
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2',
             "org.junit.jupiter:junit-jupiter-params:5.6.2",
-            "org.easymock:easymock:5.2.0",
+            "org.easymock:easymock:5.4.0",
             "org.apache.logging.log4j:log4j-core:${versions.log4j}",
             'org.mockito:mockito-junit-jupiter:3.10.0',
             'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',


### PR DESCRIPTION
### Description
Add JDK-23 to the build matrix

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
