### PR TITLE
Get bwc version dynamically

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -7,9 +7,6 @@ name: Test and Build Notifications
 
 on: [push, pull_request]
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -31,12 +28,15 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
+
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -266,7 +266,21 @@ testClusters.integTest {
 }
 
 // Always be minimumCompatibilityVersion of current opensearch version(3.0.0)
-def bwcVersionShort = "2.14.0"
+// get latest 2.x version from OpenSearch 2.x branch
+static def fetchVersionProperties() {
+    def url = 'https://raw.githubusercontent.com/opensearch-project/OpenSearch/refs/heads/2.x/buildSrc/version.properties'
+    def content = new URL(url).text
+    // Use regex to extract the version number
+    def matcher = content =~ /opensearch\s*=\s*(\d+\.\d+\.\d+)/
+    if (matcher.find()) {
+        def version = matcher.group(1)
+        println("Extracted latest 2.x version: $version")
+        return version
+    } else {
+        return "2.19.0"
+    }
+}
+String bwcVersionShort = fetchVersionProperties()
 def bwcVersion = bwcVersionShort + ".0"
 def bwcOpenSearchVesion= bwcVersionShort + "-SNAPSHOT"
 def bwcPluginVersion = bwcVersion + "-SNAPSHOT"


### PR DESCRIPTION
### Description
remove hardcoded bwc version and replace it with fetching latest value from OpenSearch core

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
