### PR TITLE
Use java-agent Gradle plugin to support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -57,7 +57,6 @@ buildscript {
 apply plugin: 'base'
 apply plugin: 'jacoco'
 apply plugin: 'io.gitlab.arturbosch.detekt'
-apply plugin: 'opensearch.java-agent'
 apply from: 'build-tools/merged-coverage.gradle'
 
 allprojects {

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -57,6 +57,7 @@ buildscript {
 apply plugin: 'base'
 apply plugin: 'jacoco'
 apply plugin: 'io.gitlab.arturbosch.detekt'
+apply plugin: 'opensearch.java-agent'
 apply from: 'build-tools/merged-coverage.gradle'
 
 allprojects {
@@ -82,26 +83,6 @@ allprojects {
         compileKotlin.kotlinOptions.jvmTarget = "21"
         compileTestKotlin.kotlinOptions.jvmTarget = "21"
         compileKotlin.dependsOn ktlint
-    }
-
-    configurations {
-        agent
-    }
-
-    task prepareAgent(type: Copy) {
-        from(configurations.agent)
-        into "$buildDir/agent"
-    }
-
-    dependencies {
-        agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-        agent "org.opensearch:opensearch-agent:${opensearch_version}"
-        agent "net.bytebuddy:byte-buddy:1.17.5"
-    }
-
-    tasks.withType(Test) {
-        dependsOn prepareAgent
-        jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
     }
 }
 

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -57,6 +57,7 @@ buildscript {
 apply plugin: 'base'
 apply plugin: 'jacoco'
 apply plugin: 'io.gitlab.arturbosch.detekt'
+apply plugin: 'opensearch.java-agent'
 apply from: 'build-tools/merged-coverage.gradle'
 
 allprojects {

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -24,6 +24,7 @@ apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.java'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-rest-test'
+apply plugin: 'opensearch.java-agent'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -24,7 +24,6 @@ apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.java'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.java-rest-test'
-apply plugin: 'opensearch.java-agent'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -33,6 +33,7 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.testclusters'
+apply plugin: 'opensearch.java-agent'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 


### PR DESCRIPTION
### Description

Use java-agent Gradle plugin to support phasing off SecurityManager usage in favor of Java Agent

### Related Issues

Please see: https://github.com/opensearch-project/job-scheduler/pull/762

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
