### PR TITLE
Migrated create, get, update, delete, search client api calls to remote metadata sdk client

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -193,7 +193,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             postRequest.id(id)
         }
 
-        val response: IndexResponse = sdkClient.suspendUntilTimeout {
+        val response: IndexResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.putDataObjectAsync(postRequest.build()).whenComplete(it)
         }
         return if (response.result != DocWriteResponse.Result.CREATED) {
@@ -227,7 +227,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             .id(id)
             .build()
 
-        val response: GetResponse = sdkClient.suspendUntilTimeout {
+        val response: GetResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.getDataObjectAsync(getRequest).whenComplete(it)
         }
         return parseNotificationConfigDoc(id, response)
@@ -285,7 +285,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             .searchSourceBuilder(sourceBuilder)
             .build()
 
-        val response: SearchResponse = sdkClient.suspendUntilTimeout {
+        val response: SearchResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.searchDataObjectAsync(searchRequest).whenComplete(it)
         }
         val result = NotificationConfigSearchResult(request.fromIndex.toLong(), response, searchHitParser)
@@ -309,7 +309,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             .overwriteIfExists(true)
             .build()
 
-        val response: IndexResponse = sdkClient.suspendUntilTimeout {
+        val response: IndexResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.putDataObjectAsync(putRequest).whenComplete(it)
         }
         if (response.result != DocWriteResponse.Result.UPDATED) {
@@ -328,7 +328,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             .id(id)
             .build()
 
-        val response: DeleteResponse = sdkClient.suspendUntilTimeout {
+        val response: DeleteResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.deleteDataObjectAsync(deleteRequest).whenComplete(it)
         }
         if (response.result != DocWriteResponse.Result.DELETED) {
@@ -355,7 +355,7 @@ internal object NotificationConfigIndex : ConfigOperations {
             )
         }
 
-        val response: BulkResponse = sdkClient.suspendUntilTimeout {
+        val response: BulkResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
             sdkClient.bulkDataObjectAsync(bulkDeleteRequest).whenComplete(it)
         }
         val mutableMap = mutableMapOf<String, RestStatus>()

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -10,17 +10,12 @@ import org.opensearch.action.DocWriteResponse
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
 import org.opensearch.action.admin.indices.create.CreateIndexResponse
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
-import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
-import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.delete.DeleteResponse
-import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.get.MultiGetRequest
 import org.opensearch.action.get.MultiGetResponse
-import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
-import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.service.ClusterService
@@ -49,13 +44,18 @@ import org.opensearch.notifications.settings.PluginSettings
 import org.opensearch.notifications.util.SecureIndexClient
 import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntil
 import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntilTimeout
+import org.opensearch.remote.metadata.client.BulkDataObjectRequest
+import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
+import org.opensearch.remote.metadata.client.GetDataObjectRequest
+import org.opensearch.remote.metadata.client.PutDataObjectRequest
 import org.opensearch.remote.metadata.client.SdkClient
+import org.opensearch.remote.metadata.client.SearchDataObjectRequest
+import org.opensearch.remote.metadata.client.suspendUntilTimeout
 import org.opensearch.script.Script
 import org.opensearch.search.SearchHit
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.sort.SortOrder
 import org.opensearch.transport.client.Client
-import java.lang.IllegalArgumentException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -185,14 +185,16 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {
         createIndex()
-        val indexRequest = IndexRequest(INDEX_NAME)
-            .source(configDoc.toXContent())
-            .create(true)
+        val postRequest = PutDataObjectRequest.builder()
+            .index(INDEX_NAME)
+            .dataObject({ builder, params -> configDoc.toXContent(builder, params) })
+            .overwriteIfExists(false)
         if (id != null) {
-            indexRequest.id(id)
+            postRequest.id(id)
         }
-        val response: IndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            index(indexRequest, it)
+
+        val response: IndexResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.putDataObjectAsync(postRequest.build()).whenComplete(it)
         }
         return if (response.result != DocWriteResponse.Result.CREATED) {
             log.warn("$LOG_PREFIX:createNotificationConfig - response:$response")
@@ -220,9 +222,13 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun getNotificationConfig(id: String): NotificationConfigDocInfo? {
         createIndex()
-        val getRequest = GetRequest(INDEX_NAME).id(id)
-        val response: GetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            get(getRequest, it)
+        val getRequest = GetDataObjectRequest.builder()
+            .index(INDEX_NAME)
+            .id(id)
+            .build()
+
+        val response: GetResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.getDataObjectAsync(getRequest).whenComplete(it)
         }
         return parseNotificationConfigDoc(id, response)
     }
@@ -274,11 +280,13 @@ internal object NotificationConfigIndex : ConfigOperations {
         }
         ConfigQueryHelper.addQueryFilters(query, request.filterParams)
         sourceBuilder.query(query)
-        val searchRequest = SearchRequest()
+        val searchRequest = SearchDataObjectRequest.builder()
             .indices(INDEX_NAME)
-            .source(sourceBuilder)
-        val response: SearchResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            search(searchRequest, it)
+            .searchSourceBuilder(sourceBuilder)
+            .build()
+
+        val response: SearchResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.searchDataObjectAsync(searchRequest).whenComplete(it)
         }
         val result = NotificationConfigSearchResult(request.fromIndex.toLong(), response, searchHitParser)
         log.info(
@@ -294,12 +302,15 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun updateNotificationConfig(id: String, notificationConfigDoc: NotificationConfigDoc): Boolean {
         createIndex()
-        val indexRequest = IndexRequest(INDEX_NAME)
-            .source(notificationConfigDoc.toXContent())
-            .create(false)
+        val putRequest = PutDataObjectRequest.builder()
+            .index(INDEX_NAME)
             .id(id)
-        val response: IndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            index(indexRequest, it)
+            .dataObject({ builder, params -> notificationConfigDoc.toXContent(builder, params) })
+            .overwriteIfExists(true)
+            .build()
+
+        val response: IndexResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.putDataObjectAsync(putRequest).whenComplete(it)
         }
         if (response.result != DocWriteResponse.Result.UPDATED) {
             log.warn("$LOG_PREFIX:updateNotificationConfig failed for $id; response:$response")
@@ -312,12 +323,13 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun deleteNotificationConfig(id: String): Boolean {
         createIndex()
-        val deleteRequest = DeleteRequest()
+        val deleteRequest = DeleteDataObjectRequest.builder()
             .index(INDEX_NAME)
             .id(id)
+            .build()
 
-        val response: DeleteResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            delete(deleteRequest, it)
+        val response: DeleteResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.deleteDataObjectAsync(deleteRequest).whenComplete(it)
         }
         if (response.result != DocWriteResponse.Result.DELETED) {
             log.warn("$LOG_PREFIX:deleteNotificationConfig failed for $id; response:$response")
@@ -330,15 +342,21 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus> {
         createIndex()
-        val bulkRequest = BulkRequest()
+
+        val bulkDeleteRequest = BulkDataObjectRequest.builder()
+            .globalIndex(INDEX_NAME)
+            .build()
         ids.forEach {
-            val deleteRequest = DeleteRequest()
-                .index(INDEX_NAME)
-                .id(it)
-            bulkRequest.add(deleteRequest)
+            bulkDeleteRequest.add(
+                DeleteDataObjectRequest.builder()
+                    .index(INDEX_NAME)
+                    .id(it)
+                    .build()
+            )
         }
-        val response: BulkResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            bulk(bulkRequest, it)
+
+        val response: BulkResponse = sdkClient.suspendUntilTimeout {
+            sdkClient.bulkDataObjectAsync(bulkDeleteRequest).whenComplete(it)
         }
         val mutableMap = mutableMapOf<String, RestStatus>()
         response.forEach {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SdkClientUtils.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/SdkClientUtils.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.remote.metadata.client
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.index.engine.VersionConflictEngineException
+import org.opensearch.remote.metadata.common.SdkClientUtils
+import java.util.function.BiConsumer
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Suspends the coroutine until an SdkClient async operation completes or times out, with parsing and exception handling.
+ *
+ * @param timeoutMs The timeout in milliseconds for the operation (default: 60secs).
+ * @param block A lambda that receives a [BiConsumer] to handle the [CompletionStage]'s result or exception.
+ * @return The parsed result of type [R] (e.g., [IndexResponse], [GetResponse]) after converting the raw response.
+ * @throws TimeoutCancellationException If the operation exceeds [timeoutMs].
+ * @throws IllegalArgumentException If the raw response does not have a `parser()` method or cannot be parsed to [R].
+ */
+suspend inline fun <Raw : Any, reified R : Any> SdkClient.suspendUntilTimeout(
+    timeoutMs: Long = 60000L,
+    crossinline block: SdkClient.(BiConsumer<Raw, Throwable?>) -> Unit
+): R {
+    try {
+        val rawResponse: Raw = withTimeout(timeoutMs) {
+            suspendCancellableCoroutine { cont ->
+                block(
+                    BiConsumer<Raw, Throwable?> { result, exception ->
+                        if (exception != null) {
+                            cont.resumeWithException(SdkClientUtils.unwrapAndConvertToException(exception))
+                        } else {
+                            cont.resume(result)
+                        }
+                    }
+                )
+            }
+        }
+        val parser = rawResponse::class.java.getMethod("parser").invoke(rawResponse) as? XContentParser
+            ?: throw IllegalArgumentException("Missing parser() on ${rawResponse::class.simpleName}")
+        val parsed = R::class.java.getMethod("fromXContent", XContentParser::class.java)
+            .invoke(null, parser) as? R
+            ?: throw IllegalArgumentException("Failed to parse response into ${R::class.simpleName}")
+        return parsed
+    } catch (e: Throwable) {
+        throw handleException(e)
+    }
+}
+
+/**
+ * Centralized Method for Handling different types of exceptions,
+ * transforming them into appropriate OpenSearch exceptions
+ *
+ * @param exception The exception to process
+ * @return The appropriate matching exception found
+ */
+fun handleException(exception: Throwable): Throwable {
+    if (isVersionConflict(exception)) {
+        return OpenSearchStatusException(
+            exception.message ?: "Version conflict occurred",
+            RestStatus.CONFLICT
+        )
+    }
+    return exception
+}
+
+/**
+ * Checks if an exception represents a version conflict.
+ *
+ * @param exception The exception to check.
+ * @return True if the exception or its cause is a [VersionConflictEngineException], false otherwise.
+ */
+private fun isVersionConflict(exception: Throwable): Boolean {
+    val cause = exception.cause ?: exception
+    return cause is VersionConflictEngineException ||
+        (cause is OpenSearchStatusException && cause.cause is VersionConflictEngineException)
+}


### PR DESCRIPTION
### Description
Migrated the following api calls to remote metadata sdk client:
1. Index
2. Get
3. Delete
4. Search
5. Bulk

Added common exception handler for sdk client

An Example of Get Request Migration from Existing client:
```
val getRequest = GetRequest(INDEX_NAME).id(id)
val response: GetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
    get(getRequest, it)
}
```
Remote Metadata sdk client
```
val getRequest = GetDataObjectRequest.builder()
  .index(INDEX_NAME)
  .id(id)
  .build()

val response: GetResponse = sdkClient.suspendUntilTimeout {
    sdkClient.getDataObjectAsync(getRequest).whenComplete(it)
}
```



 
Note: This is a follow up to the https://github.com/opensearch-project/notifications/pull/1020 of [Opensearch Remote Metadata SDKClient](https://github.com/opensearch-project/opensearch-remote-metadata-sdk) with Notifications Plugin.

### Related Issues
- Resolves : #1024
- Related to https://github.com/opensearch-project/notifications/issues/1019

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
