### PR TITLE
bump up to 2.19.3

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.2-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.3-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.3.0-SNAPSHOT -> 2.3.0.0-SNAPSHOT


### PR DESCRIPTION
bump opensearch version  up to 2.19.3

Alerting CI fails due this version mismatch : https://github.com/opensearch-project/alerting/actions/runs/15622111726/job/44292671234?pr=1861