### PR TITLE
Add Mattermost as ConfigType for notifications channel 

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -75,6 +75,13 @@ object ConfigIndexingActions {
     }
 
     @Suppress("UnusedPrivateMember")
+    private fun validateMattermostConfig(slack: Slack, user: User?) {
+        require(slack.url.contains(Regex("https://.*/hooks/.*"))) {
+            "Wrong webhook url. Should match \"https://.*/hooks/.*\""
+        }
+    }
+
+    @Suppress("UnusedPrivateMember")
     private fun validateWebhookConfig(webhook: Webhook, user: User?) {
         // TODO: URL validation with rules
     }
@@ -172,6 +179,7 @@ object ConfigIndexingActions {
             ConfigType.SLACK -> validateSlackConfig(config.configData as Slack, user)
             ConfigType.CHIME -> validateChimeConfig(config.configData as Chime, user)
             ConfigType.MICROSOFT_TEAMS -> validateMicrosoftTeamsConfig(config.configData as MicrosoftTeams, user)
+            ConfigType.MATTERMOST -> validateMattermostConfig(config.configData as Slack, user)
             ConfigType.WEBHOOK -> validateWebhookConfig(config.configData as Webhook, user)
             ConfigType.EMAIL -> validateEmailConfig(config.configData as Email, user)
             ConfigType.SMTP_ACCOUNT -> validateSmtpAccountConfig(config.configData as SmtpAccount, user)


### PR DESCRIPTION
### Description

Companion common-utils PR: https://github.com/opensearch-project/common-utils/pull/853

This PR adds a new ConfigType called `Mattermost` to the notifications ConfigType enum. Mattermost accepts the same payload format as Slack, but different URL naming. Since OpenSearch 3.0.0, users are saying they can no longer use the "Slack" notification channel type for other slack-like communication platforms like mattermost because of the URL validation logic. This PR seeks to establish a separate channel type for those other communication platforms like Discord, RocketChat, Zulip and Mattermost

### Related Issues

Part of https://github.com/opensearch-project/notifications/issues/1048

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
