### PR TITLE
Upgrade gradle to 8.14.3 and run CI checks with JDK24

### DIFF
--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os:
           - ubuntu-24.04-arm  # arm64-preview
           - ubuntu-24.04  # x64
@@ -88,7 +88,7 @@ jobs:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'signing'
-    id "com.netflix.nebula.ospackage" version "11.5.0"
+    id "com.netflix.nebula.ospackage" version "12.0.0"
 }
 
 repositories {

--- a/notifications/gradle/wrapper/gradle-wrapper.properties
+++ b/notifications/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -23,7 +23,7 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 plugins {
     id "com.dorongold.task-tree" version "2.1.1"
-    id "com.netflix.nebula.ospackage" version "11.5.0"
+    id "com.netflix.nebula.ospackage" version "12.0.0"
     id "de.undercouch.download" version "5.6.0"
 }
 


### PR DESCRIPTION
### Description

Upgrade gradle to 8.14.3 and run CI checks with JDK24

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
