### PR TITLE
Remove start param to exclude task publishPluginZipPublicationToMavenLocal

### DIFF
--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -10,4 +10,3 @@ include ":core-spi"
 
 project(":core").name = rootProject.name + "-core"
 project(":core-spi").name = rootProject.name + "-core" + "-spi"
-startParameter.excludedTaskNames += ["publishPluginZipPublicationToMavenLocal"]


### PR DESCRIPTION
### Description

This change allows a developer to perform `./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=true -i` to publish a zip of the notifications repo to maven local.


Resolves https://github.com/opensearch-project/notifications/issues/1067

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
