### PR TITLE
Fix issue publishing maven snapshots by forcing slf4j version from gradle version catalog

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -131,6 +131,7 @@ configurations.all {
         force "org.apache.httpcomponents.core5:httpcore5-h2:5.3.3"
         force "jakarta.json:jakarta.json-api:2.1.3"
         force "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
+        force "org.slf4j:slf4j-api:${versions.slf4j}"
     }
 }
 


### PR DESCRIPTION
### Description

Fix issue publishing maven snapshots by forcing slf4j version from gradle version catalog

```
Required by:
    project :notifications > org.opensearch.client:opensearch-rest-client:3.3.0-SNAPSHOT:20250917.152728-98
Caused by: org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.VersionConflictException: Conflict found for module 'org.slf4j:slf4j-api': between versions 2.0.17 and 1.7.36
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.validateVersionConflicts(DependencyGraphBuilder.java:554)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.validateGraph(DependencyGraphBuilder.java:432)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.resolve(DependencyGraphBuilder.java:172)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver.resolve(DependencyGraphResolver.java:125)
```

### Related Issues

Ref: https://github.com/opensearch-project/notifications/actions/runs/17410029596/job/50618172116

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
