### PR TITLE
Fix: Microsoft Teams notifications using Adaptive Cards

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/client/DestinationHttpClient.kt
@@ -39,9 +39,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Collections
 import kotlin.collections.HashSet
 
-/**
- * This class handles the connections to the given Destination.
- */
+/** This class handles the connections to the given Destination. */
 class DestinationHttpClient {
 
     private val httpClient: CloseableHttpClient
@@ -58,30 +56,40 @@ class DestinationHttpClient {
     companion object {
         private val log by logger(DestinationHttpClient::class.java)
 
-        /**
-         * all valid response status
-         */
-        private val VALID_RESPONSE_STATUS = Collections.unmodifiableSet(
-            HashSet(
-                listOf(
-                    RestStatus.OK.status,
-                    RestStatus.CREATED.status,
-                    RestStatus.ACCEPTED.status,
-                    RestStatus.NON_AUTHORITATIVE_INFORMATION.status,
-                    RestStatus.NO_CONTENT.status,
-                    RestStatus.RESET_CONTENT.status,
-                    RestStatus.PARTIAL_CONTENT.status,
-                    RestStatus.MULTI_STATUS.status
+        /** all valid response status */
+        private val VALID_RESPONSE_STATUS =
+            Collections.unmodifiableSet(
+                HashSet(
+                    listOf(
+                        RestStatus.OK.status,
+                        RestStatus.CREATED.status,
+                        RestStatus.ACCEPTED.status,
+                        RestStatus.NON_AUTHORITATIVE_INFORMATION.status,
+                        RestStatus.NO_CONTENT.status,
+                        RestStatus.RESET_CONTENT.status,
+                        RestStatus.PARTIAL_CONTENT.status,
+                        RestStatus.MULTI_STATUS.status
+                    )
                 )
             )
-        )
 
         private fun createHttpClient(): CloseableHttpClient {
-            val config: RequestConfig = RequestConfig.custom()
-                .setConnectTimeout(Timeout.ofMilliseconds(PluginSettings.connectionTimeout.toLong()))
-                .setConnectionRequestTimeout(Timeout.ofMilliseconds(PluginSettings.connectionTimeout.toLong()))
-                .setResponseTimeout(Timeout.ofMilliseconds(PluginSettings.socketTimeout.toLong()))
-                .build()
+            val config: RequestConfig =
+                RequestConfig.custom()
+                    .setConnectTimeout(
+                        Timeout.ofMilliseconds(
+                            PluginSettings.connectionTimeout.toLong()
+                        )
+                    )
+                    .setConnectionRequestTimeout(
+                        Timeout.ofMilliseconds(
+                            PluginSettings.connectionTimeout.toLong()
+                        )
+                    )
+                    .setResponseTimeout(
+                        Timeout.ofMilliseconds(PluginSettings.socketTimeout.toLong())
+                    )
+                    .build()
             val connectionManager = PoolingHttpClientConnectionManager()
             connectionManager.maxTotal = PluginSettings.maxConnections
             connectionManager.defaultMaxPerRoute = PluginSettings.maxConnectionsPerRoute
@@ -97,7 +105,11 @@ class DestinationHttpClient {
     }
 
     @Throws(Exception::class)
-    fun execute(destination: WebhookDestination, message: MessageContent, referenceId: String): String {
+    fun execute(
+        destination: WebhookDestination,
+        message: MessageContent,
+        referenceId: String
+    ): String {
         var response: CloseableHttpResponse? = null
         return try {
             // validate webhook url against host_deny_list in plugin settings
@@ -115,17 +127,19 @@ class DestinationHttpClient {
     }
 
     @Throws(Exception::class)
-    private fun getHttpResponse(destination: WebhookDestination, message: MessageContent): CloseableHttpResponse {
+    private fun getHttpResponse(
+        destination: WebhookDestination,
+        message: MessageContent
+    ): CloseableHttpResponse {
         var httpRequest: HttpUriRequestBase = HttpPost(destination.url)
 
         if (destination is CustomWebhookDestination) {
             httpRequest = constructHttpRequest(destination.method, destination.url)
-            if (destination.headerParams.isEmpty()) {
-                // set default header
-                httpRequest.setHeader("Content-type", "application/json")
-            } else {
-                for ((key, value) in destination.headerParams.entries) httpRequest.setHeader(key, value)
-            }
+            for ((key, value) in destination.headerParams.entries) httpRequest.setHeader(key, value)
+        }
+
+        if (destination is MicrosoftTeamsDestination) {
+            httpRequest.setHeader("Content-Type", "application/json")
         }
 
         val entity = StringEntity(buildRequestBody(destination, message), StandardCharsets.UTF_8)
@@ -139,16 +153,21 @@ class DestinationHttpClient {
             HttpPost.METHOD_NAME -> HttpPost(url)
             HttpPut.METHOD_NAME -> HttpPut(url)
             HttpPatch.METHOD_NAME -> HttpPatch(url)
-            else -> throw IllegalArgumentException(
-                "Invalid or empty method supplied. Only POST, PUT and PATCH are allowed"
-            )
+            else ->
+                throw IllegalArgumentException(
+                    "Invalid or empty method supplied. Only POST, PUT and PATCH are allowed"
+                )
         }
     }
 
     @Throws(IOException::class)
     fun getResponseString(response: CloseableHttpResponse): String {
         val entity: HttpEntity = response.entity ?: return "{}"
-        val responseString = EntityUtils.toString(entity, PluginSettings.maxHttpResponseSize / 2) // Java char is 2 bytes
+        val responseString =
+            EntityUtils.toString(
+                entity,
+                PluginSettings.maxHttpResponseSize / 2
+            ) // Java char is 2 bytes
         // DeliveryStatus need statusText must not be empty, convert empty response to {}
         return if (responseString.isNullOrEmpty()) "{}" else responseString
     }
@@ -162,24 +181,55 @@ class DestinationHttpClient {
     }
 
     fun buildRequestBody(destination: WebhookDestination, message: MessageContent): String {
-        val builder = MediaTypeRegistry.contentBuilder(XContentType.JSON)
-        val keyName = when (destination) {
-            // Slack webhook request body has required "text" as key name https://api.slack.com/messaging/webhooks
-            // Chime webhook request body has required "Content" as key name
-            // Microsoft Teams webhook request body has required "text" as key name https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors
-            // Customer webhook allows input as json or plain text, so we just return the message as it is
-            is SlackDestination -> "text"
-            is ChimeDestination -> "Content"
-            is MicrosoftTeamsDestination -> "text"
-            is CustomWebhookDestination -> return message.textDescription
-            else -> throw IllegalArgumentException(
-                "Invalid destination type is provided, Only Slack, Chime, Microsoft Teams and CustomWebhook are allowed"
-            )
+        if (destination is MicrosoftTeamsDestination) {
+            val builder = MediaTypeRegistry.contentBuilder(XContentType.JSON)
+            builder.startObject()
+                .startArray("attachments")
+                .startObject()
+                .field("contentType", "application/vnd.microsoft.card.adaptive")
+                .startObject("content")
+                .field("type", "AdaptiveCard")
+                .field("version", "1.2")
+                .startArray("body")
+                .startObject()
+                .field("type", "TextBlock")
+                .field("text", message.title)
+                .field("weight", "Bolder")
+                .field("color", "Attention")
+                .endObject()
+                .startObject()
+                .field("type", "TextBlock")
+                .field("text", message.textDescription)
+                .field("wrap", true)
+                .endObject()
+                .endArray()
+                .endObject()
+                .endObject()
+                .endArray()
+                .endObject()
+            return builder.string()
         }
 
-        builder.startObject()
-            .field(keyName, message.buildMessageWithTitle())
-            .endObject()
+        val builder = MediaTypeRegistry.contentBuilder(XContentType.JSON)
+        val keyName =
+            when (destination) {
+                // Slack webhook request body has required "text" as key name
+                // https://api.slack.com/messaging/webhooks
+                // Chime webhook request body has required "Content" as key name
+                // Microsoft Teams webhook request body has required "text" as key name
+                // https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors
+                // Customer webhook allows input as json or plain text, so we just return the
+                // message as it is
+                is SlackDestination -> "text"
+                is ChimeDestination -> "Content"
+                is CustomWebhookDestination -> return message.textDescription
+                else ->
+                    throw IllegalArgumentException(
+                        "Invalid destination type is provided, Only Slack, Chime, Microsoft Teams and CustomWebhook are allowed"
+                    )
+            }
+
+        builder.startObject().field(keyName, message.buildMessageWithTitle()).endObject()
         return builder.string()
     }
 }

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/MicrosoftTeamsDestinationTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/destinations/MicrosoftTeamsDestinationTests.kt
@@ -50,21 +50,26 @@ internal class MicrosoftTeamsDestinationTests {
 
     @BeforeEach
     fun setup() {
-        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in the unit tests
+        // Stubbing isHostInDenylist() so it doesn't attempt to resolve hosts that don't exist in
+        // the unit tests
         mockkStatic("org.opensearch.notifications.spi.utils.ValidationHelpersKt")
-        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns false
-        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns listOf(IPAddressString("174.0.0.0"))
+        every { org.opensearch.notifications.spi.utils.isHostInDenylist(any(), any()) } returns
+            false
+        every { org.opensearch.notifications.spi.utils.getResolvedIps(any()) } returns
+            listOf(IPAddressString("174.0.0.0"))
     }
 
     @Test
     fun `test MicrosoftTeams message null entity response`() {
-        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
+        val mockHttpClient: CloseableHttpClient =
+            EasyMock.createMock(CloseableHttpClient::class.java)
 
         // The DestinationHttpClient replaces a null entity with "{}".
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
 
         val httpResponse = mockk<CloseableHttpResponse>()
-        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java)))
+            .andReturn(httpResponse)
 
         every { httpResponse.code } returns RestStatus.OK.status
         every { httpResponse.entity } returns null
@@ -72,18 +77,21 @@ internal class MicrosoftTeamsDestinationTests {
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
-        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
+        DestinationTransportProvider.destinationTransportMap =
+            mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
 
         val title = "test MicrosoftTeams"
-        val messageText = "Message gughjhjlkh Body emoji test: :) :+1: " +
-            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
-            "@All All Present member callout: @Present"
+        val messageText =
+            "Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present"
         val url = "https://abc/com"
 
         val destination = MicrosoftTeamsDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualMicrosoftTeamsResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "ref")
+        val actualMicrosoftTeamsResponse: DestinationMessageResponse =
+            NotificationCoreImpl.sendMessage(destination, message, "ref")
 
         assertEquals(expectedWebhookResponse.statusText, actualMicrosoftTeamsResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualMicrosoftTeamsResponse.statusCode)
@@ -91,29 +99,34 @@ internal class MicrosoftTeamsDestinationTests {
 
     @Test
     fun `test MicrosoftTeams message empty entity response`() {
-        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
+        val mockHttpClient: CloseableHttpClient =
+            EasyMock.createMock(CloseableHttpClient::class.java)
         val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, "{}")
 
         val httpResponse = mockk<CloseableHttpResponse>()
-        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java)))
+            .andReturn(httpResponse)
         every { httpResponse.code } returns RestStatus.OK.status
         every { httpResponse.entity } returns StringEntity("")
         EasyMock.replay(mockHttpClient)
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
-        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
+        DestinationTransportProvider.destinationTransportMap =
+            mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
 
         val title = "test MicrosoftTeams"
-        val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
-            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
-            "@All All Present member callout: @Present\"}"
+        val messageText =
+            "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}"
         val url = "https://abc/com"
 
         val destination = MicrosoftTeamsDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualMicrosoftTeamsResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "ref")
+        val actualMicrosoftTeamsResponse: DestinationMessageResponse =
+            NotificationCoreImpl.sendMessage(destination, message, "ref")
 
         assertEquals(expectedWebhookResponse.statusText, actualMicrosoftTeamsResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualMicrosoftTeamsResponse.statusCode)
@@ -122,29 +135,35 @@ internal class MicrosoftTeamsDestinationTests {
     @Test
     fun `test MicrosoftTeams message non-empty entity response`() {
         val responseContent = "It worked!"
-        val mockHttpClient: CloseableHttpClient = EasyMock.createMock(CloseableHttpClient::class.java)
-        val expectedWebhookResponse = DestinationMessageResponse(RestStatus.OK.status, responseContent)
+        val mockHttpClient: CloseableHttpClient =
+            EasyMock.createMock(CloseableHttpClient::class.java)
+        val expectedWebhookResponse =
+            DestinationMessageResponse(RestStatus.OK.status, responseContent)
 
         val httpResponse = mockk<CloseableHttpResponse>()
-        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java))).andReturn(httpResponse)
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost::class.java)))
+            .andReturn(httpResponse)
         every { httpResponse.code } returns RestStatus.OK.status
         every { httpResponse.entity } returns StringEntity(responseContent)
         EasyMock.replay(mockHttpClient)
 
         val httpClient = DestinationHttpClient(mockHttpClient)
         val webhookDestinationTransport = WebhookDestinationTransport(httpClient)
-        DestinationTransportProvider.destinationTransportMap = mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
+        DestinationTransportProvider.destinationTransportMap =
+            mapOf(DestinationType.MICROSOFT_TEAMS to webhookDestinationTransport)
 
         val title = "test MicrosoftTeams"
-        val messageText = "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
-            "link test: http://sample.com email test: marymajor@example.com All member callout: " +
-            "@All All Present member callout: @Present\"}"
+        val messageText =
+            "{\"Content\":\"Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}"
         val url = "https://abc/com"
 
         val destination = MicrosoftTeamsDestination(url)
         val message = MessageContent(title, messageText)
 
-        val actualMicrosoftTeamsResponse: DestinationMessageResponse = NotificationCoreImpl.sendMessage(destination, message, "ref")
+        val actualMicrosoftTeamsResponse: DestinationMessageResponse =
+            NotificationCoreImpl.sendMessage(destination, message, "ref")
 
         assertEquals(expectedWebhookResponse.statusText, actualMicrosoftTeamsResponse.statusText)
         assertEquals(expectedWebhookResponse.statusCode, actualMicrosoftTeamsResponse.statusCode)
@@ -152,17 +171,16 @@ internal class MicrosoftTeamsDestinationTests {
 
     @Test
     fun `test url missing should throw IllegalArgumentException with message`() {
-        val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
-            MicrosoftTeamsDestination("")
-        }
+        val exception =
+            Assertions.assertThrows(IllegalArgumentException::class.java) {
+                MicrosoftTeamsDestination("")
+            }
         assertEquals("url is null or empty", exception.message)
     }
 
     @Test
     fun testUrlInvalidMessage() {
-        assertThrows<MalformedURLException> {
-            ChimeDestination("invalidUrl")
-        }
+        assertThrows<MalformedURLException> { ChimeDestination("invalidUrl") }
     }
 
     @ParameterizedTest
@@ -175,7 +193,8 @@ internal class MicrosoftTeamsDestinationTests {
         val title = "test MicrosoftTeams"
         val messageText = "line1${escapeSequence}line2"
         val url = "https://abc/com"
-        val expectedRequestBody = """{"text":"$title\n\nline1${rawString}line2"}"""
+        val expectedRequestBody =
+            """{"attachments":[{"contentType":"application/vnd.microsoft.card.adaptive","content":{"type":"AdaptiveCard","version":"1.2","body":[{"type":"TextBlock","text":"$title","weight":"Bolder","color":"Attention"},{"type":"TextBlock","text":"line1${rawString}line2","wrap":true}]}}]}"""
         val destination = MicrosoftTeamsDestination(url)
         val message = MessageContent(title, messageText)
         val actualRequestBody = httpClient.buildRequestBody(destination, message)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.notifications.index
 
-import java.time.Instant
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.commons.authuser.User
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
@@ -40,6 +39,7 @@ import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.notifications.model.DocMetadata
 import org.opensearch.notifications.model.NotificationConfigDoc
 import org.opensearch.notifications.security.UserAccess
+import java.time.Instant
 
 /** NotificationConfig indexing operation actions. */
 @Suppress("TooManyFunctions")
@@ -64,9 +64,9 @@ object ConfigIndexingActions {
     @Suppress("UnusedPrivateMember")
     private fun validateChimeConfig(chime: Chime, user: User?) {
         require(
-                chime.url.contains(
-                        Regex("https://hooks\\.chime\\.aws/incomingwebhooks/.*\\?token=")
-                )
+            chime.url.contains(
+                Regex("https://hooks\\.chime\\.aws/incomingwebhooks/.*\\?token=")
+            )
         ) {
             "Wrong Chime url. Should contain \"hooks.chime.aws/incomingwebhooks/\" and \"?token=\""
         }
@@ -100,8 +100,8 @@ object ConfigIndexingActions {
     private suspend fun validateEmailConfig(email: Email, user: User?) {
         if (email.emailGroupIds.contains(email.emailAccountID)) {
             throw OpenSearchStatusException(
-                    "Config IDs ${email.emailAccountID} is in both emailAccountID and emailGroupIds",
-                    RestStatus.BAD_REQUEST
+                "Config IDs ${email.emailAccountID} is in both emailAccountID and emailGroupIds",
+                RestStatus.BAD_REQUEST
             )
         }
         val configIds = setOf(email.emailAccountID).union(email.emailGroupIds)
@@ -109,50 +109,50 @@ object ConfigIndexingActions {
         if (configDocs.size != configIds.size) {
             val availableIds = configDocs.map { it.docInfo.id }.toSet()
             throw OpenSearchStatusException(
-                    "Config IDs not found:${configIds.filterNot { availableIds.contains(it) }}",
-                    RestStatus.NOT_FOUND
+                "Config IDs not found:${configIds.filterNot { availableIds.contains(it) }}",
+                RestStatus.NOT_FOUND
             )
         }
         configDocs.forEach {
             // Validate that the config type matches the data
             when (it.configDoc.config.configType) {
                 ConfigType.EMAIL_GROUP ->
-                        if (it.docInfo.id == email.emailAccountID) {
-                            // Email Group ID is specified as Email Account ID
-                            Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_ACCOUNT_ID.counter
-                                    .increment()
-                            throw OpenSearchStatusException(
-                                    "configId ${it.docInfo.id} is not a valid email account ID",
-                                    RestStatus.NOT_ACCEPTABLE
-                            )
-                        }
+                    if (it.docInfo.id == email.emailAccountID) {
+                        // Email Group ID is specified as Email Account ID
+                        Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_ACCOUNT_ID.counter
+                            .increment()
+                        throw OpenSearchStatusException(
+                            "configId ${it.docInfo.id} is not a valid email account ID",
+                            RestStatus.NOT_ACCEPTABLE
+                        )
+                    }
                 ConfigType.SMTP_ACCOUNT ->
-                        if (it.docInfo.id != email.emailAccountID) {
-                            // Email Account ID is specified as Email Group ID
-                            Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_GROUP_ID.counter
-                                    .increment()
-                            throw OpenSearchStatusException(
-                                    "configId ${it.docInfo.id} is not a valid email group ID",
-                                    RestStatus.NOT_ACCEPTABLE
-                            )
-                        }
+                    if (it.docInfo.id != email.emailAccountID) {
+                        // Email Account ID is specified as Email Group ID
+                        Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_GROUP_ID.counter
+                            .increment()
+                        throw OpenSearchStatusException(
+                            "configId ${it.docInfo.id} is not a valid email group ID",
+                            RestStatus.NOT_ACCEPTABLE
+                        )
+                    }
                 ConfigType.SES_ACCOUNT ->
-                        if (it.docInfo.id != email.emailAccountID) {
-                            // Email Account ID is specified as Email Group ID
-                            Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_GROUP_ID.counter
-                                    .increment()
-                            throw OpenSearchStatusException(
-                                    "configId ${it.docInfo.id} is not a valid email group ID",
-                                    RestStatus.NOT_ACCEPTABLE
-                            )
-                        }
+                    if (it.docInfo.id != email.emailAccountID) {
+                        // Email Account ID is specified as Email Group ID
+                        Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_INVALID_EMAIL_GROUP_ID.counter
+                            .increment()
+                        throw OpenSearchStatusException(
+                            "configId ${it.docInfo.id} is not a valid email group ID",
+                            RestStatus.NOT_ACCEPTABLE
+                        )
+                    }
                 else -> {
                     // Config ID is neither Email Group ID or valid Email Account ID
                     Metrics.NOTIFICATIONS_CONFIG_USER_ERROR_NEITHER_EMAIL_NOR_GROUP.counter
-                            .increment()
+                        .increment()
                     throw OpenSearchStatusException(
-                            "configId ${it.docInfo.id} is not a valid email group ID or email account ID",
-                            RestStatus.NOT_ACCEPTABLE
+                        "configId ${it.docInfo.id} is not a valid email group ID or email account ID",
+                        RestStatus.NOT_ACCEPTABLE
                     )
                 }
             }
@@ -161,8 +161,8 @@ object ConfigIndexingActions {
             if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
-                        "Permission denied for NotificationConfig ${it.docInfo.id}",
-                        RestStatus.FORBIDDEN
+                    "Permission denied for NotificationConfig ${it.docInfo.id}",
+                    RestStatus.FORBIDDEN
                 )
             }
         }
@@ -186,23 +186,23 @@ object ConfigIndexingActions {
     private suspend fun validateConfig(config: NotificationConfig, user: User?) {
         when (config.configType) {
             ConfigType.NONE ->
-                    throw OpenSearchStatusException(
-                            "NotificationConfig with type NONE is not acceptable",
-                            RestStatus.NOT_ACCEPTABLE
-                    )
+                throw OpenSearchStatusException(
+                    "NotificationConfig with type NONE is not acceptable",
+                    RestStatus.NOT_ACCEPTABLE
+                )
             ConfigType.SLACK -> validateSlackConfig(config.configData as Slack, user)
             ConfigType.CHIME -> validateChimeConfig(config.configData as Chime, user)
             ConfigType.MICROSOFT_TEAMS ->
-                    validateMicrosoftTeamsConfig(config.configData as MicrosoftTeams, user)
+                validateMicrosoftTeamsConfig(config.configData as MicrosoftTeams, user)
             ConfigType.MATTERMOST -> validateMattermostConfig(config.configData as Slack, user)
             ConfigType.WEBHOOK -> validateWebhookConfig(config.configData as Webhook, user)
             ConfigType.EMAIL -> validateEmailConfig(config.configData as Email, user)
             ConfigType.SMTP_ACCOUNT ->
-                    validateSmtpAccountConfig(config.configData as SmtpAccount, user)
+                validateSmtpAccountConfig(config.configData as SmtpAccount, user)
             ConfigType.SES_ACCOUNT ->
-                    validateSesAccountConfig(config.configData as SesAccount, user)
+                validateSesAccountConfig(config.configData as SesAccount, user)
             ConfigType.EMAIL_GROUP ->
-                    validateEmailGroupConfig(config.configData as EmailGroup, user)
+                validateEmailGroupConfig(config.configData as EmailGroup, user)
             ConfigType.SNS -> validateSnsConfig(config.configData as Sns, user)
         }
     }
@@ -214,8 +214,8 @@ object ConfigIndexingActions {
      * @return [CreateNotificationConfigResponse]
      */
     suspend fun create(
-            request: CreateNotificationConfigRequest,
-            user: User?
+        request: CreateNotificationConfigRequest,
+        user: User?
     ): CreateNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-create")
         userAccess.validateUser(user)
@@ -225,13 +225,13 @@ object ConfigIndexingActions {
         val configDoc = NotificationConfigDoc(metadata, request.notificationConfig)
         val docId = operations.createNotificationConfig(configDoc, request.configId)
         docId
-                ?: run {
-                    Metrics.NOTIFICATIONS_CONFIG_CREATE_SYSTEM_ERROR.counter.increment()
-                    throw OpenSearchStatusException(
-                            "NotificationConfig Creation failed",
-                            RestStatus.INTERNAL_SERVER_ERROR
-                    )
-                }
+            ?: run {
+                Metrics.NOTIFICATIONS_CONFIG_CREATE_SYSTEM_ERROR.counter.increment()
+                throw OpenSearchStatusException(
+                    "NotificationConfig Creation failed",
+                    RestStatus.INTERNAL_SERVER_ERROR
+                )
+            }
         return CreateNotificationConfigResponse(docId)
     }
 
@@ -242,35 +242,35 @@ object ConfigIndexingActions {
      * @return [UpdateNotificationConfigResponse]
      */
     suspend fun update(
-            request: UpdateNotificationConfigRequest,
-            user: User?
+        request: UpdateNotificationConfigRequest,
+        user: User?
     ): UpdateNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-update ${request.configId}")
         userAccess.validateUser(user)
         validateConfig(request.notificationConfig, user)
         val currentConfigDoc = operations.getNotificationConfig(request.configId)
         currentConfigDoc
-                ?: run {
-                    Metrics.NOTIFICATIONS_CONFIG_UPDATE_USER_ERROR_INVALID_CONFIG_ID.counter
-                            .increment()
-                    throw OpenSearchStatusException(
-                            "NotificationConfig ${request.configId} not found",
-                            RestStatus.NOT_FOUND
-                    )
-                }
+            ?: run {
+                Metrics.NOTIFICATIONS_CONFIG_UPDATE_USER_ERROR_INVALID_CONFIG_ID.counter
+                    .increment()
+                throw OpenSearchStatusException(
+                    "NotificationConfig ${request.configId} not found",
+                    RestStatus.NOT_FOUND
+                )
+            }
 
         val currentMetadata = currentConfigDoc.configDoc.metadata
         if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
-                    "Permission denied for NotificationConfig ${request.configId}",
-                    RestStatus.FORBIDDEN
+                "Permission denied for NotificationConfig ${request.configId}",
+                RestStatus.FORBIDDEN
             )
         }
         if (currentConfigDoc.configDoc.config.configType != request.notificationConfig.configType) {
             throw OpenSearchStatusException(
-                    "Config type cannot be changed after creation",
-                    RestStatus.CONFLICT
+                "Config type cannot be changed after creation",
+                RestStatus.CONFLICT
             )
         }
 
@@ -279,8 +279,8 @@ object ConfigIndexingActions {
         if (!operations.updateNotificationConfig(request.configId, newConfigData)) {
             Metrics.NOTIFICATIONS_CONFIG_UPDATE_SYSTEM_ERROR.counter.increment()
             throw OpenSearchStatusException(
-                    "NotificationConfig Update failed",
-                    RestStatus.INTERNAL_SERVER_ERROR
+                "NotificationConfig Update failed",
+                RestStatus.INTERNAL_SERVER_ERROR
             )
         }
         return UpdateNotificationConfigResponse(request.configId)
@@ -293,8 +293,8 @@ object ConfigIndexingActions {
      * @return [GetNotificationConfigResponse]
      */
     suspend fun get(
-            request: GetNotificationConfigRequest,
-            user: User?
+        request: GetNotificationConfigRequest,
+        user: User?
     ): GetNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-get $request")
         userAccess.validateUser(user)
@@ -315,29 +315,29 @@ object ConfigIndexingActions {
         log.info("$LOG_PREFIX:NotificationConfig-info $configId")
         val configDoc = operations.getNotificationConfig(configId)
         configDoc
-                ?: run {
-                    Metrics.NOTIFICATIONS_CONFIG_INFO_USER_ERROR_INVALID_CONFIG_ID.counter
-                            .increment()
-                    throw OpenSearchStatusException(
-                            "NotificationConfig $configId not found",
-                            RestStatus.NOT_FOUND
-                    )
-                }
+            ?: run {
+                Metrics.NOTIFICATIONS_CONFIG_INFO_USER_ERROR_INVALID_CONFIG_ID.counter
+                    .increment()
+                throw OpenSearchStatusException(
+                    "NotificationConfig $configId not found",
+                    RestStatus.NOT_FOUND
+                )
+            }
         val metadata = configDoc.configDoc.metadata
         if (!userAccess.doesUserHaveAccess(user, metadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
-                    "Permission denied for NotificationConfig $configId",
-                    RestStatus.FORBIDDEN
+                "Permission denied for NotificationConfig $configId",
+                RestStatus.FORBIDDEN
             )
         }
         val configInfo =
-                NotificationConfigInfo(
-                        configId,
-                        metadata.lastUpdateTime,
-                        metadata.createdTime,
-                        configDoc.configDoc.config
-                )
+            NotificationConfigInfo(
+                configId,
+                metadata.lastUpdateTime,
+                metadata.createdTime,
+                configDoc.configDoc.config
+            )
         return GetNotificationConfigResponse(NotificationConfigSearchResult(configInfo))
     }
 
@@ -355,8 +355,8 @@ object ConfigIndexingActions {
             configDocs.forEach { mutableSet.remove(it.docInfo.id) }
             Metrics.NOTIFICATIONS_CONFIG_INFO_USER_ERROR_SET_NOT_FOUND.counter.increment()
             throw OpenSearchStatusException(
-                    "NotificationConfig $mutableSet not found",
-                    RestStatus.NOT_FOUND
+                "NotificationConfig $mutableSet not found",
+                RestStatus.NOT_FOUND
             )
         }
         configDocs.forEach {
@@ -364,20 +364,20 @@ object ConfigIndexingActions {
             if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
-                        "Permission denied for NotificationConfig ${it.docInfo.id}",
-                        RestStatus.FORBIDDEN
+                    "Permission denied for NotificationConfig ${it.docInfo.id}",
+                    RestStatus.FORBIDDEN
                 )
             }
         }
         val configSearchResult =
-                configDocs.map {
-                    NotificationConfigInfo(
-                            it.docInfo.id!!,
-                            it.configDoc.metadata.lastUpdateTime,
-                            it.configDoc.metadata.createdTime,
-                            it.configDoc.config
-                    )
-                }
+            configDocs.map {
+                NotificationConfigInfo(
+                    it.docInfo.id!!,
+                    it.configDoc.metadata.lastUpdateTime,
+                    it.configDoc.metadata.createdTime,
+                    it.configDoc.config
+                )
+            }
         return GetNotificationConfigResponse(NotificationConfigSearchResult(configSearchResult))
     }
 
@@ -388,12 +388,12 @@ object ConfigIndexingActions {
      * @return [GetNotificationConfigResponse]
      */
     private suspend fun getAll(
-            request: GetNotificationConfigRequest,
-            user: User?
+        request: GetNotificationConfigRequest,
+        user: User?
     ): GetNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-getAll")
         val searchResult =
-                operations.getAllNotificationConfigs(userAccess.getSearchAccessInfo(user), request)
+            operations.getAllNotificationConfigs(userAccess.getSearchAccessInfo(user), request)
         return GetNotificationConfigResponse(searchResult)
     }
 
@@ -404,8 +404,8 @@ object ConfigIndexingActions {
      * @return [GetChannelListResponse]
      */
     suspend fun getChannelList(
-            request: GetChannelListRequest,
-            user: User?
+        request: GetChannelListRequest,
+        user: User?
     ): GetChannelListResponse {
         log.info("$LOG_PREFIX:getChannelList $request")
         userAccess.validateUser(user)
@@ -413,35 +413,35 @@ object ConfigIndexingActions {
         val filterParams = mapOf(Pair("config_type", supportedChannelListString))
         val getAllRequest = GetNotificationConfigRequest(filterParams = filterParams)
         val getAllResult =
-                operations.getAllNotificationConfigs(
-                        userAccess.getSearchAccessInfo(user),
-                        getAllRequest
-                )
+            operations.getAllNotificationConfigs(
+                userAccess.getSearchAccessInfo(user),
+                getAllRequest
+            )
         val searchResult =
-                getAllResult.objectList.map {
-                    val configId = it.configId
-                    val config = it.notificationConfig
-                    Channel(
-                            configId,
-                            config.name,
-                            config.description,
-                            config.configType,
-                            config.isEnabled
-                    )
-                }
+            getAllResult.objectList.map {
+                val configId = it.configId
+                val config = it.notificationConfig
+                Channel(
+                    configId,
+                    config.name,
+                    config.description,
+                    config.configType,
+                    config.isEnabled
+                )
+            }
         val ChannelList = ChannelList(searchResult)
         return GetChannelListResponse(ChannelList)
     }
 
     private fun getSupportedChannelList(): List<String> {
         return listOf(
-                ConfigType.SLACK.tag,
-                ConfigType.CHIME.tag,
-                ConfigType.MICROSOFT_TEAMS.tag,
-                ConfigType.WEBHOOK.tag,
-                ConfigType.EMAIL.tag,
-                ConfigType.SNS.tag,
-                ConfigType.MATTERMOST.tag
+            ConfigType.SLACK.tag,
+            ConfigType.CHIME.tag,
+            ConfigType.MICROSOFT_TEAMS.tag,
+            ConfigType.WEBHOOK.tag,
+            ConfigType.EMAIL.tag,
+            ConfigType.SNS.tag,
+            ConfigType.MATTERMOST.tag
         )
     }
 
@@ -456,28 +456,28 @@ object ConfigIndexingActions {
         userAccess.validateUser(user)
         val currentConfigDoc = operations.getNotificationConfig(configId)
         currentConfigDoc
-                ?: run {
-                    Metrics.NOTIFICATIONS_CONFIG_DELETE_USER_ERROR_INVALID_CONFIG_ID.counter
-                            .increment()
-                    throw OpenSearchStatusException(
-                            "NotificationConfig $configId not found",
-                            RestStatus.NOT_FOUND
-                    )
-                }
+            ?: run {
+                Metrics.NOTIFICATIONS_CONFIG_DELETE_USER_ERROR_INVALID_CONFIG_ID.counter
+                    .increment()
+                throw OpenSearchStatusException(
+                    "NotificationConfig $configId not found",
+                    RestStatus.NOT_FOUND
+                )
+            }
 
         val currentMetadata = currentConfigDoc.configDoc.metadata
         if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
             Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
-                    "Permission denied for NotificationConfig $configId",
-                    RestStatus.FORBIDDEN
+                "Permission denied for NotificationConfig $configId",
+                RestStatus.FORBIDDEN
             )
         }
         if (!operations.deleteNotificationConfig(configId)) {
             Metrics.NOTIFICATIONS_CONFIG_DELETE_SYSTEM_ERROR.counter.increment()
             throw OpenSearchStatusException(
-                    "NotificationConfig $configId delete failed",
-                    RestStatus.REQUEST_TIMEOUT
+                "NotificationConfig $configId delete failed",
+                RestStatus.REQUEST_TIMEOUT
             )
         }
         return DeleteNotificationConfigResponse(mapOf(Pair(configId, RestStatus.OK)))
@@ -490,8 +490,8 @@ object ConfigIndexingActions {
      * @return [DeleteNotificationConfigResponse]
      */
     private suspend fun delete(
-            configIds: Set<String>,
-            user: User?
+        configIds: Set<String>,
+        user: User?
     ): DeleteNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-delete $configIds")
         userAccess.validateUser(user)
@@ -501,8 +501,8 @@ object ConfigIndexingActions {
             configDocs.forEach { mutableSet.remove(it.docInfo.id) }
             Metrics.NOTIFICATIONS_CONFIG_DELETE_USER_ERROR_SET_NOT_FOUND.counter.increment()
             throw OpenSearchStatusException(
-                    "NotificationConfig $mutableSet not found",
-                    RestStatus.NOT_FOUND
+                "NotificationConfig $mutableSet not found",
+                RestStatus.NOT_FOUND
             )
         }
         configDocs.forEach {
@@ -510,8 +510,8 @@ object ConfigIndexingActions {
             if (!userAccess.doesUserHaveAccess(user, currentMetadata.access)) {
                 Metrics.NOTIFICATIONS_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
-                        "Permission denied for NotificationConfig ${it.docInfo.id}",
-                        RestStatus.FORBIDDEN
+                    "Permission denied for NotificationConfig ${it.docInfo.id}",
+                    RestStatus.FORBIDDEN
                 )
             }
         }
@@ -526,8 +526,8 @@ object ConfigIndexingActions {
      * @return [DeleteNotificationConfigResponse]
      */
     suspend fun delete(
-            request: DeleteNotificationConfigRequest,
-            user: User?
+        request: DeleteNotificationConfigRequest,
+        user: User?
     ): DeleteNotificationConfigResponse {
         log.info("$LOG_PREFIX:NotificationConfig-delete ${request.configIds}")
         return if (request.configIds.size == 1) {

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/MicrosoftTeamsNotificationConfigCrudIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/MicrosoftTeamsNotificationConfigCrudIT.kt
@@ -159,7 +159,7 @@ class MicrosoftTeamsNotificationConfigCrudIT : PluginRestTestCase() {
             fail("Expected wrong Microsoft Teams URL.")
         } catch (exception: ResponseException) {
             Assert.assertEquals(
-                "Wrong Microsoft Teams url. Should contain \"webhook.office.com\"",
+                "Wrong Microsoft Teams URL. Allowed domains: webhook.office.com, powerplatform.com, logic.azure.com",
                 jsonify(getResponseBody(exception.response))["error"].asJsonObject["reason"].asString
             )
         }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/ConfigIndexingActionsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/ConfigIndexingActionsTests.kt
@@ -18,16 +18,33 @@ class ConfigIndexingActionsTests {
     @Test
     fun `test validate microsoft teams`() {
         val user = User()
-        var microsoftTeams = MicrosoftTeams("https://abcdefg.webhook.office.com/webhookb2/12345567abcdefg")
+        var microsoftTeams =
+            MicrosoftTeams("https://abcdefg.webhook.office.com/webhookb2/12345567abcdefg")
         validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
-        microsoftTeams = MicrosoftTeams("https://abcde.efg.webhook.office.com/webhookb2/12345567abcdefg")
+        microsoftTeams =
+            MicrosoftTeams("https://abcde.efg.webhook.office.com/webhookb2/12345567abcdefg")
         validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
-        microsoftTeams = MicrosoftTeams("http://abcdefg.webhook.office.com/webhookb2/12345567abcdefg")
-        assertFails { validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user) }
+
+        // New allowed domains
+        microsoftTeams = MicrosoftTeams("https://test.powerplatform.com/webhook")
+        validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
+        microsoftTeams = MicrosoftTeams("https://test.logic.azure.com/webhook")
+        validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
+
+        // Simple contains check now allows http if domain is present
+        microsoftTeams =
+            MicrosoftTeams("http://abcdefg.webhook.office.com/webhookb2/12345567abcdefg")
+        validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
+
+        // Invalid domains
         microsoftTeams = MicrosoftTeams("https://abcdefg.webhook.abc.com/webhookb2/12345567abcdefg")
-        assertFails { validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user) }
+        assertFails {
+            validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
+        }
         microsoftTeams = MicrosoftTeams("https://abcdefg.abc.com")
-        assertFails { validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user) }
+        assertFails {
+            validateMicrosoftTeamsConfig.invoke(ConfigIndexingActions, microsoftTeams, user)
+        }
     }
 
     @Test
@@ -37,9 +54,15 @@ class ConfigIndexingActionsTests {
         validateSlackConfig.invoke(ConfigIndexingActions, slack, user)
         slack = Slack("https://hooks.gov-slack.com/services/123456789/123456789/123456789")
         validateSlackConfig.invoke(ConfigIndexingActions, slack, user)
-        slack = Slack("https://hooks.slack.com/services/samplesamplesamplesamplesamplesamplesamplesamplesample")
+        slack =
+            Slack(
+                "https://hooks.slack.com/services/samplesamplesamplesamplesamplesamplesamplesamplesample"
+            )
         validateSlackConfig.invoke(ConfigIndexingActions, slack, user)
-        slack = Slack("https://hooks.gov-slack.com/services/samplesamplesamplesamplesamplesamplesamplesamplesample")
+        slack =
+            Slack(
+                "https://hooks.gov-slack.com/services/samplesamplesamplesamplesamplesamplesamplesamplesample"
+            )
         validateSlackConfig.invoke(ConfigIndexingActions, slack, user)
         slack = Slack("http://hooks.slack.com/services/123456789/123456789/123456789/123456789")
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
@@ -51,11 +74,20 @@ class ConfigIndexingActionsTests {
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
         slack = Slack("https://hooks.slack.com/123456789/123456789/123456789/123456789/123456789")
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
-        slack = Slack("https://hooks.gov-slack.com/123456789/123456789/123456789/123456789/123456789")
+        slack =
+            Slack(
+                "https://hooks.gov-slack.com/123456789/123456789/123456789/123456789/123456789"
+            )
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
-        slack = Slack("https://hook.slack.com/services/123456789/123456789/123456789/123456789/123456789")
+        slack =
+            Slack(
+                "https://hook.slack.com/services/123456789/123456789/123456789/123456789/123456789"
+            )
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
-        slack = Slack("https://hook.gov-slack.com/services/123456789/123456789/123456789/123456789/123456789")
+        slack =
+            Slack(
+                "https://hook.gov-slack.com/services/123456789/123456789/123456789/123456789/123456789"
+            )
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
         slack = Slack("https://hooks.slack.com/")
         assertFails { validateSlackConfig.invoke(ConfigIndexingActions, slack, user) }
@@ -68,7 +100,10 @@ class ConfigIndexingActionsTests {
         val user = User()
         var chime = Chime("https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456")
         validateChimeConfig.invoke(ConfigIndexingActions, chime, user)
-        chime = Chime("https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456&test=123")
+        chime =
+            Chime(
+                "https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456&test=123"
+            )
         validateChimeConfig.invoke(ConfigIndexingActions, chime, user)
         chime = Chime("https://hooks.chime.aws/incomingwebhooks/sample_chime_url")
         assertFails { validateChimeConfig.invoke(ConfigIndexingActions, chime, user) }
@@ -91,21 +126,24 @@ class ConfigIndexingActionsTests {
         @JvmStatic
         fun initialize() {
             /* use reflection to get private method */
-            validateMicrosoftTeamsConfig = ConfigIndexingActions::class.java.getDeclaredMethod(
-                "validateMicrosoftTeamsConfig",
-                MicrosoftTeams::class.java,
-                User::class.java
-            )
-            validateSlackConfig = ConfigIndexingActions::class.java.getDeclaredMethod(
-                "validateSlackConfig",
-                Slack::class.java,
-                User::class.java
-            )
-            validateChimeConfig = ConfigIndexingActions::class.java.getDeclaredMethod(
-                "validateChimeConfig",
-                Chime::class.java,
-                User::class.java
-            )
+            validateMicrosoftTeamsConfig =
+                ConfigIndexingActions::class.java.getDeclaredMethod(
+                    "validateMicrosoftTeamsConfig",
+                    MicrosoftTeams::class.java,
+                    User::class.java
+                )
+            validateSlackConfig =
+                ConfigIndexingActions::class.java.getDeclaredMethod(
+                    "validateSlackConfig",
+                    Slack::class.java,
+                    User::class.java
+                )
+            validateChimeConfig =
+                ConfigIndexingActions::class.java.getDeclaredMethod(
+                    "validateChimeConfig",
+                    Chime::class.java,
+                    User::class.java
+                )
 
             validateMicrosoftTeamsConfig.isAccessible = true
             validateSlackConfig.isAccessible = true


### PR DESCRIPTION
Updated DestinationHttpClient to use Adaptive Card schema (v1.2) for Teams.

Added Content-Type: application/json header for Teams requests.

Relaxed URL validation to support Logic Apps and Power Automate domains.

Updated unit tests.

### Description
helps in integrating microsoft Teams new webhook url and send adaptive card notifications

### Related Issues
Resolves #1106 Issue to be closed when this PR is merged]


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
