### PR TITLE
Make notifications aware of the FIPS build param (-Pcrypto.standard=FIPS-140-3)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -45,5 +45,5 @@ jobs:
       - name: publish snapshots to maven
         run: |
           cd notifications/
-          ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository "-Pcrypto.standard=FIPS-140-3"
 

--- a/.github/workflows/notifications-test-and-build-workflow.yml
+++ b/.github/workflows/notifications-test-and-build-workflow.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd notifications
-          su `id -un 1000` -c "./gradlew build"
+          su `id -un 1000` -c "./gradlew build \"-Pcrypto.standard=FIPS-140-3\""
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -123,7 +123,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: |
           cd notifications
-          ./gradlew build ${{ env.BUILD_ARGS }}
+          ./gradlew build ${{ env.BUILD_ARGS }} "-Pcrypto.standard=FIPS-140-3"
         env:
           _JAVA_OPTIONS: ${{ matrix.os_java_options }}
 

--- a/.github/workflows/security-notifications-test-workflow.yml
+++ b/.github/workflows/security-notifications-test-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cd notifications
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew integTest -Dsecurity=true -Dhttps=true --tests '*IT'"
+          su `id -un 1000` -c "./gradlew integTest \"-Pcrypto.standard=FIPS-140-3\" -Dsecurity=true -Dhttps=true --tests '*IT'"
 
       - name: Upload failed logs
         uses: actions/upload-artifact@v4

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -17,6 +17,7 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSession
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
+import org.opensearch.gradle.info.FipsBuildParams
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.OpenSearchCluster
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -117,8 +118,11 @@ configurations.testImplementation {
     exclude module: "securemock"
 }
 
-configurations.testRuntimeClasspath {
-    exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
+// When building with -Pcrypto.standard=FIPS-140-3, bcprov is provided by OpenSearch
+if (FipsBuildParams.isInFipsMode()) {
+    configurations.all {
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
+    }
 }
 
 configurations.all {


### PR DESCRIPTION
### Description

Similar to https://github.com/opensearch-project/flow-framework/pull/1322. This PR ensures that notifications becomes aware of the FIPS build param to treat bouncycastle dependencies as provided when present.

### Related Issues

Resolves https://github.com/opensearch-project/notifications/issues/1139

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
