### PR TITLE
Add multi_tenancy_enabled setting and update settings prefix (#1147)

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -40,6 +40,7 @@ import org.opensearch.notifications.resthandler.SendTestMessageRestHandler
 import org.opensearch.notifications.security.UserAccessManager
 import org.opensearch.notifications.send.SendMessageActionHelper
 import org.opensearch.notifications.settings.PluginSettings
+import org.opensearch.notifications.settings.PluginSettings.MULTI_TENANCY_ENABLED
 import org.opensearch.notifications.settings.PluginSettings.REMOTE_METADATA_ENDPOINT
 import org.opensearch.notifications.settings.PluginSettings.REMOTE_METADATA_REGION
 import org.opensearch.notifications.settings.PluginSettings.REMOTE_METADATA_SERVICE_NAME
@@ -129,7 +130,7 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
                 REMOTE_METADATA_ENDPOINT_KEY to REMOTE_METADATA_ENDPOINT.get(settings),
                 REMOTE_METADATA_REGION_KEY to REMOTE_METADATA_REGION.get(settings),
                 REMOTE_METADATA_SERVICE_NAME_KEY to REMOTE_METADATA_SERVICE_NAME.get(settings),
-                TENANT_AWARE_KEY to "false"
+                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString()
             ),
             client.threadPool().executor(ThreadPool.Names.GENERIC)
         )

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -161,10 +161,23 @@ internal object PluginSettings {
         Dynamic
     )
 
+    /**
+     * Settings Key-prefix for remote metadata configuration.
+     */
+    private const val REMOTE_METADATA_KEY_PREFIX = "plugins.notifications"
+
+    /** This setting enables multi-tenancy for the remote metadata SDK client */
+    val MULTI_TENANCY_ENABLED: Setting<Boolean> = Setting.boolSetting(
+        "$REMOTE_METADATA_KEY_PREFIX.multi_tenancy_enabled",
+        false,
+        NodeScope,
+        Setting.Property.Final
+    )
+
     /** This setting sets the remote metadata store type  */
     val REMOTE_METADATA_STORE_TYPE: Setting<String?> = Setting
         .simpleString(
-            "plugins.alerting.$REMOTE_METADATA_TYPE_KEY",
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_TYPE_KEY",
             NodeScope,
             Setting.Property.Final
         )
@@ -172,7 +185,7 @@ internal object PluginSettings {
     /** This setting sets the remote metadata endpoint  */
     val REMOTE_METADATA_ENDPOINT: Setting<String?> = Setting
         .simpleString(
-            "plugins.alerting.$REMOTE_METADATA_ENDPOINT_KEY",
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_ENDPOINT_KEY",
             NodeScope,
             Setting.Property.Final
         )
@@ -180,7 +193,7 @@ internal object PluginSettings {
     /** This setting sets the remote metadata region  */
     val REMOTE_METADATA_REGION: Setting<String?> = Setting
         .simpleString(
-            "plugins.alerting.$REMOTE_METADATA_REGION_KEY",
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_REGION_KEY",
             NodeScope,
             Setting.Property.Final
         )
@@ -188,7 +201,7 @@ internal object PluginSettings {
     /** This setting sets the remote metadata service name  */
     val REMOTE_METADATA_SERVICE_NAME: Setting<String?> = Setting
         .simpleString(
-            "plugins.alerting.$REMOTE_METADATA_SERVICE_NAME_KEY",
+            "$REMOTE_METADATA_KEY_PREFIX.$REMOTE_METADATA_SERVICE_NAME_KEY",
             NodeScope,
             Setting.Property.Final
         )
@@ -211,6 +224,7 @@ internal object PluginSettings {
             OPERATION_TIMEOUT_MS,
             DEFAULT_ITEMS_QUERY_COUNT,
             FILTER_BY_BACKEND_ROLES,
+            MULTI_TENANCY_ENABLED,
             REMOTE_METADATA_REGION,
             REMOTE_METADATA_ENDPOINT,
             REMOTE_METADATA_STORE_TYPE,

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -28,6 +28,7 @@ internal class PluginSettingsTests {
     private val legacyAlertingFilterByBackendRolesKey = "opendistro.alerting.filter_by_backend_roles"
     private val alertingFilterByBackendRolesKey = "plugins.alerting.filter_by_backend_roles"
     private val filterByBackendRolesKey = "$generalKeyPrefix.filter_by_backend_roles"
+    private val multiTenancyEnabledKey = "plugins.notifications.multi_tenancy_enabled"
 
     private val defaultSettings = Settings.builder()
         .put(operationTimeoutKey, 60000L)
@@ -209,5 +210,32 @@ internal class PluginSettingsTests {
         )
         PluginSettings.addSettingsUpdateConsumer(clusterService)
         Assertions.assertEquals(true, PluginSettings.isRbacEnabled())
+    }
+
+    @Test
+    fun `test multi_tenancy_enabled setting defaults to false`() {
+        Assertions.assertEquals(false, PluginSettings.MULTI_TENANCY_ENABLED.getDefault(Settings.EMPTY))
+    }
+
+    @Test
+    fun `test multi_tenancy_enabled setting is registered`() {
+        val settings = plugin.settings
+        Assert.assertTrue(settings.contains(PluginSettings.MULTI_TENANCY_ENABLED))
+    }
+
+    @Test
+    fun `test multi_tenancy_enabled setting reads from config`() {
+        val settings = Settings.builder()
+            .put(multiTenancyEnabledKey, true)
+            .build()
+        Assertions.assertEquals(true, PluginSettings.MULTI_TENANCY_ENABLED.get(settings))
+    }
+
+    @Test
+    fun `test remote metadata settings use plugins notifications prefix`() {
+        Assertions.assertTrue(PluginSettings.REMOTE_METADATA_STORE_TYPE.key.startsWith("plugins.notifications."))
+        Assertions.assertTrue(PluginSettings.REMOTE_METADATA_ENDPOINT.key.startsWith("plugins.notifications."))
+        Assertions.assertTrue(PluginSettings.REMOTE_METADATA_REGION.key.startsWith("plugins.notifications."))
+        Assertions.assertTrue(PluginSettings.REMOTE_METADATA_SERVICE_NAME.key.startsWith("plugins.notifications."))
     }
 }


### PR DESCRIPTION
### Description
Add multi-tenancy configuration support to the notifications plugin's remote metadata SDK client integration.

Previously, the `TENANT_AWARE_KEY` was hardcoded to `false` when creating the SDK client, which meant tenant-aware mode could not be enabled via configuration. 

introduces a new `plugins.notifications.multi_tenancy_enabled` boolean setting (default false) that drives the `TENANT_AWARE_KEY` value, allowing enabling of tenant-aware mode through `opensearch.yml` configuration.

Additionally, all remote metadata settings have been updated from the `plugins.alerting.*` prefix to `plugins.notifications.*` for proper namespace isolation. The affected settings are:
- plugins.notifications.multi_tenancy_enabled (new)
- plugins.notifications.remote_metadata_type (previously plugins.alerting.remote_metadata_type)
- plugins.notifications.remote_metadata_endpoint (previously plugins.alerting.remote_metadata_endpoint)
- plugins.notifications.remote_metadata_region (previously plugins.alerting.remote_metadata_region)
- plugins.notifications.remote_metadata_service_name (previously plugins.alerting.remote_metadata_service_name)

Added Unit tests to verify the new plugin settings.

### Related Issues
Resolves https://github.com/opensearch-project/notifications/issues/1147

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
