### PR TITLE
Fix build due to jackson version conflict

### DIFF
--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -122,9 +122,14 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group.startsWith('com.fasterxml.jackson')) {
+                def version = details.requested.module.name == 'jackson-annotations'
+                    ? versions.jackson_annotations
+                    : versions.jackson
+                details.useVersion version
+            }
+        }
         force "commons-logging:commons-logging:1.3.5"
         force "commons-codec:commons-codec:1.17.1"
         force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"


### PR DESCRIPTION
### Description
Enforce com.fasterxml.jackson version to resolve version conflict

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

#1150

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
