### PR TITLE
feat: Propagate tenant ID from REST header to SDK client Requests

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -57,9 +57,11 @@ import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_
 import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY
 import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY
 import org.opensearch.remote.metadata.common.CommonValue.TENANT_AWARE_KEY
+import org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY
 import org.opensearch.repositories.RepositoriesService
 import org.opensearch.rest.RestController
 import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestHeaderDefinition
 import org.opensearch.script.ScriptService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
@@ -84,6 +86,7 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
 
         // Other global constants
         const val TEXT_QUERY_TAG = "text_query"
+        const val TENANT_ID_HEADER = "x-tenant-id"
     }
 
     /**
@@ -92,6 +95,13 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
     override fun getSettings(): List<Setting<*>> {
         log.debug("$LOG_PREFIX:getSettings")
         return PluginSettings.getAllSettings()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun getRestHeaders(): Collection<RestHeaderDefinition> {
+        return listOf(RestHeaderDefinition(TENANT_ID_HEADER, false))
     }
 
     override fun getSystemIndexDescriptors(settings: Settings?): Collection<SystemIndexDescriptor> {
@@ -130,7 +140,8 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
                 REMOTE_METADATA_ENDPOINT_KEY to REMOTE_METADATA_ENDPOINT.get(settings),
                 REMOTE_METADATA_REGION_KEY to REMOTE_METADATA_REGION.get(settings),
                 REMOTE_METADATA_SERVICE_NAME_KEY to REMOTE_METADATA_SERVICE_NAME.get(settings),
-                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString()
+                TENANT_AWARE_KEY to MULTI_TENANCY_ENABLED.get(settings).toString(),
+                TENANT_ID_FIELD_KEY to "tenant_id"
             ),
             client.threadPool().executor(ThreadPool.Names.GENERIC)
         )

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PluginBaseAction.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/action/PluginBaseAction.kt
@@ -25,7 +25,9 @@ import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indices.InvalidIndexNameException
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.NotificationPlugin.Companion.TENANT_ID_HEADER
 import org.opensearch.notifications.metrics.Metrics
+import org.opensearch.notifications.util.TenantContext
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
@@ -55,8 +57,9 @@ internal abstract class PluginBaseAction<Request : ActionRequest, Response : Act
         val userStr: String? =
             client.threadPool().threadContext.getTransient<String>(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
         val user: User? = User.parse(userStr)
+        val tenantId: String? = client.threadPool().threadContext.getHeader(TENANT_ID_HEADER)
         val storedThreadContext = client.threadPool().threadContext.newStoredContext(false)
-        scope.launch {
+        scope.launch(TenantContext(tenantId)) {
             try {
                 client.threadPool().threadContext.stashContext().use {
                     storedThreadContext.restore()

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -44,6 +44,7 @@ import org.opensearch.notifications.settings.PluginSettings
 import org.opensearch.notifications.util.SecureIndexClient
 import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntil
 import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntilTimeout
+import org.opensearch.notifications.util.currentTenantId
 import org.opensearch.remote.metadata.client.BulkDataObjectRequest
 import org.opensearch.remote.metadata.client.DeleteDataObjectRequest
 import org.opensearch.remote.metadata.client.GetDataObjectRequest
@@ -185,8 +186,10 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {
         createIndex()
+        val tenantId = currentTenantId()
         val postRequest = PutDataObjectRequest.builder()
             .index(INDEX_NAME)
+            .tenantId(tenantId)
             .dataObject({ builder, params -> configDoc.toXContent(builder, params) })
             .overwriteIfExists(false)
         if (id != null) {
@@ -225,6 +228,7 @@ internal object NotificationConfigIndex : ConfigOperations {
         val getRequest = GetDataObjectRequest.builder()
             .index(INDEX_NAME)
             .id(id)
+            .tenantId(currentTenantId())
             .build()
 
         val response: GetResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
@@ -282,6 +286,7 @@ internal object NotificationConfigIndex : ConfigOperations {
         sourceBuilder.query(query)
         val searchRequest = SearchDataObjectRequest.builder()
             .indices(INDEX_NAME)
+            .tenantId(currentTenantId())
             .searchSourceBuilder(sourceBuilder)
             .build()
 
@@ -305,6 +310,7 @@ internal object NotificationConfigIndex : ConfigOperations {
         val putRequest = PutDataObjectRequest.builder()
             .index(INDEX_NAME)
             .id(id)
+            .tenantId(currentTenantId())
             .dataObject({ builder, params -> notificationConfigDoc.toXContent(builder, params) })
             .overwriteIfExists(true)
             .build()
@@ -326,6 +332,7 @@ internal object NotificationConfigIndex : ConfigOperations {
         val deleteRequest = DeleteDataObjectRequest.builder()
             .index(INDEX_NAME)
             .id(id)
+            .tenantId(currentTenantId())
             .build()
 
         val response: DeleteResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
@@ -343,6 +350,7 @@ internal object NotificationConfigIndex : ConfigOperations {
     override suspend fun deleteNotificationConfigs(ids: Set<String>): Map<String, RestStatus> {
         createIndex()
 
+        val tenantId = currentTenantId()
         val bulkDeleteRequest = BulkDataObjectRequest.builder()
             .globalIndex(INDEX_NAME)
             .build()
@@ -351,6 +359,7 @@ internal object NotificationConfigIndex : ConfigOperations {
                 DeleteDataObjectRequest.builder()
                     .index(INDEX_NAME)
                     .id(it)
+                    .tenantId(tenantId)
                     .build()
             )
         }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/TenantContext.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/TenantContext.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.util
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Coroutine context element that carries the tenant ID for the current request.
+ * Set in [org.opensearch.notifications.action.PluginBaseAction] when launching the coroutine,
+ * and read in [org.opensearch.notifications.index.NotificationConfigIndex] when building SDK requests.
+ */
+data class TenantContext(val tenantId: String?) : AbstractCoroutineContextElement(TenantContext) {
+    companion object Key : CoroutineContext.Key<TenantContext>
+}
+
+/**
+ * Retrieves the tenant ID from the current coroutine context.
+ * Returns null if no [TenantContext] is present or if the tenant ID is not set.
+ */
+suspend fun currentTenantId(): String? = coroutineContext[TenantContext]?.tenantId

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -238,4 +238,18 @@ internal class PluginSettingsTests {
         Assertions.assertTrue(PluginSettings.REMOTE_METADATA_REGION.key.startsWith("plugins.notifications."))
         Assertions.assertTrue(PluginSettings.REMOTE_METADATA_SERVICE_NAME.key.startsWith("plugins.notifications."))
     }
+
+    @Test
+    fun `test tenant id header is registered as allowed REST header`() {
+        val headers = plugin.restHeaders
+        val headerNames = headers.map { it.name }
+        Assertions.assertTrue(headerNames.contains("x-tenant-id"))
+    }
+
+    @Test
+    fun `test tenant id header does not allow multiple values`() {
+        val headers = plugin.restHeaders
+        val tenantHeader = headers.first { it.name == "x-tenant-id" }
+        Assertions.assertFalse(tenantHeader.isMultiValueAllowed)
+    }
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/TenantContextTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/TenantContextTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.util
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class TenantContextTests {
+
+    @Test
+    fun `test currentTenantId returns tenant id when set`() {
+        runBlocking(TenantContext("test-tenant")) {
+            assertEquals("test-tenant", currentTenantId())
+        }
+    }
+
+    @Test
+    fun `test currentTenantId returns null for single tenant deployment`() {
+        runBlocking {
+            assertNull(currentTenantId())
+        }
+    }
+
+    @Test
+    fun `test currentTenantId returns null when tenant id header is absent`() {
+        runBlocking(TenantContext(null)) {
+            assertNull(currentTenantId())
+        }
+    }
+
+    @Test
+    fun `test tenant id propagates to nested operations`() {
+        runBlocking(TenantContext("parent-tenant")) {
+            launch {
+                assertEquals("parent-tenant", currentTenantId())
+            }
+        }
+    }
+
+    @Test
+    fun `test concurrent requests have isolated tenant ids`() {
+        runBlocking {
+            launch(TenantContext("tenant-a")) {
+                assertEquals("tenant-a", currentTenantId())
+            }
+            launch(TenantContext("tenant-b")) {
+                assertEquals("tenant-b", currentTenantId())
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Extract x-tenant-id header and pass it to all SDK data object requests, enabling multi-tenant data isolation for any configured remote metadata store.

### Related Issues
https://github.com/opensearch-project/notifications/issues/1161

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
