### PR TITLE
Version bump to 3.7 plus accompanying changes

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.6.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -157,6 +157,8 @@ configurations.all {
         force "io.netty:netty-resolver:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
         force "org.dafny:DafnyRuntime:4.9.0"
+        force "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+        force "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     }
 }
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/SendTestNotificationRequestTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/model/SendTestNotificationRequestTests.kt
@@ -4,13 +4,13 @@
  */
 package org.opensearch.notifications.model
 
-import com.fasterxml.jackson.core.JsonParseException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.opensearch.commons.utils.recreateObject
 import org.opensearch.notifications.createObjectFromJsonString
 import org.opensearch.notifications.getJsonString
+import org.opensearch.tools.jackson.core.JsonParseException
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 


### PR DESCRIPTION
### Description
Auto version bump PR (https://github.com/opensearch-project/notifications/pull/1156) failed due to a change in Jackson dependencies that existing code did not pick up. This PR performs the version bump along with needed changes to restabilize Notifications.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
