### PR TITLE
Route getNotificationConfigs through SdkClient

### DIFF
--- a/notifications/gradle/wrapper/gradle-wrapper.properties
+++ b/notifications/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionSha256Sum=708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -13,8 +13,6 @@ import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.opensearch.action.bulk.BulkResponse
 import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.get.GetResponse
-import org.opensearch.action.get.MultiGetRequest
-import org.opensearch.action.get.MultiGetResponse
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
@@ -212,12 +210,39 @@ internal object NotificationConfigIndex : ConfigOperations {
      */
     override suspend fun getNotificationConfigs(ids: Set<String>): List<NotificationConfigDocInfo> {
         createIndex()
-        val getRequest = MultiGetRequest()
-        ids.forEach { getRequest.add(INDEX_NAME, it) }
-        val response: MultiGetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
-            multiGet(getRequest, it)
+        val sourceBuilder = SearchSourceBuilder()
+            .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
+            .query(QueryBuilders.idsQuery().addIds(*ids.toTypedArray()))
+            .size(ids.size)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(INDEX_NAME)
+            .tenantId(currentTenantId())
+            .searchSourceBuilder(sourceBuilder)
+            .build()
+        val response: SearchResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            sdkClient.searchDataObjectAsync(searchRequest).whenComplete(it)
         }
-        return response.responses.mapNotNull { parseNotificationConfigDoc(it.id, it.response) }
+        return response.hits.hits.mapNotNull { hit ->
+            try {
+                val parser = XContentType.JSON.xContent().createParser(
+                    NamedXContentRegistry.EMPTY,
+                    LoggingDeprecationHandler.INSTANCE,
+                    hit.sourceAsString
+                )
+                parser.nextToken()
+                val doc = NotificationConfigDoc.parse(parser)
+                val info = DocInfo(
+                    id = hit.id,
+                    version = hit.version,
+                    seqNo = hit.seqNo,
+                    primaryTerm = hit.primaryTerm
+                )
+                NotificationConfigDocInfo(info, doc)
+            } catch (e: Exception) {
+                log.warn("$LOG_PREFIX:getNotificationConfigs - failed to parse ${hit.id}: ${e.message}")
+                null
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Route getNotificationConfigs through SdkClient by replacing MultiGetRequest with SearchDataObjectRequest using idsQuery

This is the only remaining operation in `NotificationConfigIndex` that bypassed the Remote Metadata SDK, going directly to the local OpenSearch client. The send notification flow calls this method to bulk-fetch channel configs before sending notifications, which fails when using a remote metadata backend with other metadata stores.                                                                                     
                                                                                                                                                                                                                      The fix is consistent with how `getAllNotificationConfigs` already performs searches through `SdkClient.searchDataObjectAsync()`.     

### Related Issues
Resolves #1224  

### Build Run
```
> Task :opensearch-notifications-core:generatePomFileForPluginZipPublication
> Task :opensearch-notifications-core:validateNebulaPom SKIPPED
> Task :opensearch-notifications-core:validatePluginZipPom UP-TO-DATE
> Task :opensearch-notifications-core:validatePom UP-TO-DATE
> Task :opensearch-notifications-core:precommit UP-TO-DATE
> Task :opensearch-notifications-core:test
> Task :opensearch-notifications-core:javaRestTest NO-SOURCE
> Task :opensearch-notifications-core-spi:jar UP-TO-DATE
> Task :opensearch-notifications-core-spi:compileTestKotlin UP-TO-DATE
> Task :opensearch-notifications-core-spi:compileTestJava NO-SOURCE
> Task :opensearch-notifications-core-spi:processTestResources NO-SOURCE
> Task :opensearch-notifications-core-spi:testClasses UP-TO-DATE
> Task :opensearch-notifications-core-spi:precommit UP-TO-DATE
> Task :opensearch-notifications-core-spi:test
> Task :opensearch-notifications-core-spi:javadoc NO-SOURCE
> Task :opensearch-notifications-core-spi:check
> Task :notifications:generatePom
> Task :notifications:assemble
> Task :opensearch-notifications-core:generatePom
> Task :opensearch-notifications-core:assemble
> Task :opensearch-notifications-core-spi:assemble UP-TO-DATE
> Task :opensearch-notifications-core-spi:build
> Task :opensearch-notifications-core:jacocoTestReport
> Task :opensearch-notifications-core:check
> Task :opensearch-notifications-core:build
> Task :notifications:jacocoTestReport
> Task :notifications:check
> Task :notifications:build
> Task :opensearch-notifications-core-spi:jacocoTestReport
> Task :jacocoReport SKIPPED
> Task :check
> Task :build

[Incubating] Problems report is available at: file:///workplace/aghilp/notifications-private-remote/notifications/notifications/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.4.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3m 33s
54 actionable tasks: 13 executed, 41 up-to-date
```

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
