### PR TITLE
Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -30,6 +30,7 @@ buildscript {
     repositories {
         // For local publish dependency
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -64,6 +65,7 @@ allprojects {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/notifications/core-spi/build.gradle
+++ b/notifications/core-spi/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-notifications'
 include ":core"
 include ":notifications"


### PR DESCRIPTION
### Description

Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins, such as integration tests run against release candidates during the release process.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror before Gradle Plugin Portal and Maven Central
- Gradle build files — Add CI mirror before Maven Central for dependency resolution

### Testing
- Verified `./gradlew assemble` completes successfully
- Ran `git diff --check`