### PR TITLE
Fix Dispatchers.IO starvation deadlock in notification send path

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -7,7 +7,7 @@ package org.opensearch.notifications.send
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.coroutineScope
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.authuser.User
@@ -111,13 +111,8 @@ object SendMessageActionHelper {
      * Send legacy notification message intended only for Index Management plugin.
      * @param request request object
      */
-    fun executeLegacyRequest(request: LegacyPublishNotificationRequest): LegacyPublishNotificationResponse {
-        val baseMessage = request.baseMessage
-        val response: LegacyDestinationResponse
-        runBlocking {
-            response = sendMessageToLegacyDestination(baseMessage)
-        }
-        return LegacyPublishNotificationResponse(response)
+    suspend fun executeLegacyRequest(request: LegacyPublishNotificationRequest): LegacyPublishNotificationResponse {
+        return LegacyPublishNotificationResponse(sendMessageToLegacyDestination(request.baseMessage))
     }
 
     /**
@@ -146,22 +141,23 @@ object SendMessageActionHelper {
      * @param message the message to send
      * @return notification delivery status for each channel
      */
-    private fun sendMessagesInParallel(
+    private suspend fun sendMessagesInParallel(
         user: User?,
         eventSource: EventSource,
         channelMap: Map<String, NotificationConfigDocInfo?>,
         childConfigMap: Map<String, NotificationConfigDocInfo?>,
         message: MessageContent
     ): List<EventStatus> {
-        val statusList: List<EventStatus>
-        // Fire all the message sending in parallel
-        runBlocking {
-            val statusDeferredList = channelMap.map {
+        // Fire all the message sending in parallel. Using coroutineScope instead of runBlocking
+        // so the parent coroutine suspends (releasing its dispatcher thread) while awaiting the
+        // children. runBlocking here would park a Dispatchers.IO thread while the children also
+        // require Dispatchers.IO threads, which deadlocks the entire dispatcher once its
+        // parallelism limit (64 by default) is reached by concurrent send requests.
+        return coroutineScope {
+            channelMap.map {
                 async(Dispatchers.IO) { sendMessageToChannel(user, eventSource, it, childConfigMap, message) }
-            }
-            statusList = statusDeferredList.awaitAll()
+            }.awaitAll()
         }
-        return statusList
     }
 
     /**
@@ -172,7 +168,7 @@ object SendMessageActionHelper {
      * @param message the message to send
      * @return notification delivery status for the channel
      */
-    private fun sendMessageToChannel(
+    private suspend fun sendMessageToChannel(
         user: User?,
         eventSource: EventSource,
         channelEntry: Map.Entry<String, NotificationConfigDocInfo?>,
@@ -270,7 +266,7 @@ object SendMessageActionHelper {
      * @param baseMessage legacy base message
      * @return notification delivery status for the legacy destination
      */
-    private fun sendMessageToLegacyDestination(baseMessage: LegacyBaseMessage): LegacyDestinationResponse {
+    private suspend fun sendMessageToLegacyDestination(baseMessage: LegacyBaseMessage): LegacyDestinationResponse {
         var message =
             MessageContent(title = "Legacy Notification", textDescription = baseMessage.messageContent)
         // These legacy destination calls do not have reference Ids, just passing 'legacy' constant
@@ -302,7 +298,7 @@ object SendMessageActionHelper {
                 // The naming is a little confusing but need to use the subject from LegacyEmailMessage as the title,
                 // so it appears as the subject of the email
                 message = MessageContent(title = baseMessage.subject, textDescription = baseMessage.messageContent)
-                runBlocking {
+                coroutineScope {
                     val emailRecipientStatus: List<EmailRecipientStatus> = recipients.map {
                         async(Dispatchers.IO) {
                             val destination = SmtpDestination(
@@ -427,7 +423,7 @@ object SendMessageActionHelper {
     /**
      * send message to email destination
      */
-    private fun sendEmailMessage(
+    private suspend fun sendEmailMessage(
         user: User?,
         email: Email,
         childConfigMap: Map<String, NotificationConfigDocInfo?>,
@@ -464,9 +460,8 @@ object SendMessageActionHelper {
             .filter { email.emailGroupIds.contains(it.docInfo.id) && !accessDeniedGroupIds.contains(it.docInfo.id) }
         val groupRecipients = groups.map { (it.configDoc.config.configData as EmailGroup).recipients }.flatten()
         val recipients = email.recipients.union(groupRecipients)
-        val emailRecipientStatus: List<EmailRecipientStatus>
         val accountConfig = accountDocInfo.configDoc.config
-        runBlocking {
+        val emailRecipientStatus: List<EmailRecipientStatus> = coroutineScope {
             val statusDeferredList = recipients.map {
                 async(Dispatchers.IO) {
                     when (accountConfig.configType) {
@@ -491,7 +486,7 @@ object SendMessageActionHelper {
                     }
                 }
             }
-            emailRecipientStatus = statusDeferredList.awaitAll() + invalidGroupIds.map {
+            statusDeferredList.awaitAll() + invalidGroupIds.map {
                 EmailRecipientStatus(
                     "unknown-recipient@example.com",
                     DeliveryStatus(RestStatus.NOT_FOUND.status.toString(), "Recipient $it not found")

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -168,6 +168,8 @@ object SendMessageActionHelper {
      * @param message the message to send
      * @return notification delivery status for the channel
      */
+    // suspend is required here because this calls sendEmailMessage, which is a suspend
+    // function (it fans out to email recipients within its own coroutineScope).
     private suspend fun sendMessageToChannel(
         user: User?,
         eventSource: EventSource,

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -247,7 +247,11 @@ internal class PluginActionTests {
 
         // Mock singleton's method by mockk framework
         mockkObject(SendMessageActionHelper)
-        every { SendMessageActionHelper.executeLegacyRequest(request) } returns response
+        every {
+            runBlocking {
+                SendMessageActionHelper.executeLegacyRequest(request)
+            }
+        } returns response
 
         val publishNotificationAction = PublishNotificationAction(
             transportService,


### PR DESCRIPTION
### Description

Fixes a permanent `Dispatchers.IO` starvation deadlock in the notification send path.

`SendMessageActionHelper` used `runBlocking` inside code already running on a `Dispatchers.IO` coroutine (`PluginBaseAction` launches every transport request on a shared `CoroutineScope(Dispatchers.IO)`). The parent coroutine parked its dispatcher thread while awaiting child `async(Dispatchers.IO)` sends that need threads from the same pool. Under sustained concurrent sends to a slow destination (e.g. a webhook that responds slowly or times out), parents eventually occupy all 64 `Dispatchers.IO` slots; from then on no child can be scheduled and no parent can complete. All Notifications APIs (including `GET /_plugins/_notifications/features`) hang until the node is restarted. Observed in production on 2.19; code is unchanged on main.

**Change:** replace all four `runBlocking` sites in `SendMessageActionHelper` with structured concurrency — the send-path functions become `suspend` functions using `coroutineScope { ... }` + `awaitAll()`, so waiting parents suspend and release their dispatcher threads instead of parking them. All call chains already terminate in `suspend` transport-action methods (`SendNotificationAction.executeRequest`, `PublishNotificationAction.executeRequest`), so no additional bridging is needed. No behavior change to what is sent, delivery statuses, or parallelism — only how waiting happens (suspension vs. thread parking).

Converted functions:
- `sendMessagesInParallel` → `suspend` + `coroutineScope` (primary deadlock site)
- `executeLegacyRequest` → `suspend`, `runBlocking` wrapper removed
- `sendEmailMessage` → `suspend` + `coroutineScope` (recipient fan-out; previously a *nested* `runBlocking` inside a child of the outer one)
- `sendMessageToLegacyDestination` → `suspend` + `coroutineScope` (legacy email branch)
- `sendMessageToChannel` → `suspend` (transitively required)

**Verification:** reproduced the deadlock on an integTest cluster (main) by flooding 200 concurrent `feature/test/{config_id}` requests at a webhook channel responding after 30s: before this change the node deadlocks permanently (jstack: exactly 64 `DefaultDispatcher-worker` threads parked in `runBlocking` at `sendMessagesInParallel`, zero threads in `DestinationHttpClient`, no recovery after the webhook is stopped). After this change, all 200 sends complete with correct delivery-failure statuses and all plugin APIs remain responsive throughout; jstack shows no parked parents. Full repro details in the linked issue.

### Related Issues

Resolves #1247

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
