### PR TITLE
Fix SES/SNS NoClassDefFoundError from Jackson 3 / HttpClient5 migration

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -119,6 +119,8 @@ configurations.all {
         force "commons-codec:commons-codec:1.13" // resolve for amazonaws
         force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}" // resolve for amazonaws
         force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpclient:${versions.httpclient}" // resolve for amazonaws
+        force "org.apache.httpcomponents:httpcore:4.4.16" // resolve for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}" // resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}" // resolve for amazonaws
@@ -140,9 +142,11 @@ dependencies {
     implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
     implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
+    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}" // Needed for amazonaws (com.amazonaws.http.AmazonHttpClient)
+    implementation "org.apache.httpcomponents:httpcore:4.4.16" // Needed for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-    implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -120,7 +120,7 @@ configurations.all {
         force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}" // resolve for amazonaws
         force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}" // resolve for amazonaws
         force "org.apache.httpcomponents:httpclient:${versions.httpclient}" // resolve for amazonaws
-        force "org.apache.httpcomponents:httpcore:4.4.16" // resolve for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
+        force "org.apache.httpcomponents:httpcore:${versions.httpcore}" // resolve for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
         force "joda-time:joda-time:2.8.1" // Resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}" // resolve for amazonaws
         force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}" // resolve for amazonaws
@@ -143,10 +143,11 @@ dependencies {
     implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}" // Needed for amazonaws (com.amazonaws.http.AmazonHttpClient)
-    implementation "org.apache.httpcomponents:httpcore:4.4.16" // Needed for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
+    implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}" // Needed for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"
     implementation "com.amazonaws:aws-java-sdk-sns:${aws_version}"

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/credentials/SesClientFactoryImplTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/credentials/SesClientFactoryImplTests.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.notifications.core.credentials
+
+import org.junit.jupiter.api.Test
+import org.opensearch.notifications.core.credentials.oss.SesClientFactoryImpl
+
+/**
+ * Reproduces a production incident where sending an SES email threw NoClassDefFoundError.
+ * AWS SDK v1 (com.amazonaws.*) needs the classic Jackson databind and Apache HttpClient/
+ * HttpCore packages, but core/build.gradle only declared their Jackson 3 / HttpClient5
+ * replacements, so both classes were missing from the runtime classpath.
+ */
+internal class SesClientFactoryImplTests {
+
+    @Test
+    fun `test createSesClient does not throw NoClassDefFoundError for jackson databind or httpclient`() {
+        SesClientFactoryImpl.createSesClient("us-west-2", null)
+    }
+}

--- a/notifications/core/src/test/kotlin/org/opensearch/notifications/core/credentials/SnsClientFactoryImplTests.kt
+++ b/notifications/core/src/test/kotlin/org/opensearch/notifications/core/credentials/SnsClientFactoryImplTests.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.notifications.core.credentials
+
+import org.junit.jupiter.api.Test
+import org.opensearch.notifications.core.credentials.oss.SnsClientFactoryImpl
+
+/**
+ * SNS counterpart to SesClientFactoryImplTests. SnsClientFactoryImpl.createSnsClient
+ * goes through the same CredentialsProviderFactory / AmazonWebServiceClient construction
+ * path as SesClientFactoryImpl, so it hit the same two NoClassDefFoundErrors (classic
+ * jackson-databind, then classic httpclient/httpcore) before core/build.gradle was fixed.
+ */
+internal class SnsClientFactoryImplTests {
+
+    @Test
+    fun `test createSnsClient does not throw NoClassDefFoundError for jackson databind or httpclient`() {
+        SnsClientFactoryImpl.createSnsClient("us-west-2", null)
+    }
+}

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -200,13 +200,20 @@ dependencies {
     compileOnly "org.slf4j:slf4j-api:${versions.slf4j}"
     compileOnly "commons-logging:commons-logging:${versions.commonslogging}"
     compileOnly "commons-codec:commons-codec:${versions.commonscodec}"
+    // httpclient (classic) is bundled by opensearch-notifications-core, which this plugin
+    // extends and shares a classloader with; bundling a second copy here causes jar hell.
+    compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
 
-    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_build}"
     api "org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}"
     implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
         exclude group: 'org.bouncycastle'
+        // jackson-databind and httpcore (classic) are bundled by opensearch-notifications-core,
+        // which this plugin extends and shares a classloader with; bundling second copies here
+        // causes jar hell.
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     }
 
 

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -200,8 +200,7 @@ dependencies {
     compileOnly "org.slf4j:slf4j-api:${versions.slf4j}"
     compileOnly "commons-logging:commons-logging:${versions.commonslogging}"
     compileOnly "commons-codec:commons-codec:${versions.commonscodec}"
-    // httpclient (classic) is bundled by opensearch-notifications-core, which this plugin
-    // extends and shares a classloader with; bundling a second copy here causes jar hell.
+    // core already bundles httpclient (classic) and shares its classloader; avoid a second copy
     compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
 
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_build}"
@@ -209,9 +208,8 @@ dependencies {
     implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
         exclude group: 'org.bouncycastle'
-        // jackson-databind and httpcore (classic) are bundled by opensearch-notifications-core,
-        // which this plugin extends and shares a classloader with; bundling second copies here
-        // causes jar hell.
+        // core already bundles jackson-databind and httpcore (classic) and shares its
+        // classloader; avoid second copies
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     }


### PR DESCRIPTION
AWS SDK v1 (com.amazonaws.*) requires classic com.fasterxml.jackson.databind and org.apache.http (HttpClient4/HttpCore4) classes internally. core/build.gradle had been migrated to Jackson 3 (tools.jackson.core) and HttpClient5 only, so SES and SNS client construction threw NoClassDefFoundError in production.

This modification restores the classic jackson-databind and httpclient/httpcore dependencies in core/build.gradle, and adjusts notifications/build.gradle (which extends core and shares its classloader) to avoid bundling duplicate copies that would otherwise trigger a jar hell failure at plugin load time.

Adds regression tests exercising the real SES/SNS client construction path.

### Description
Adds HttpClient4 and Jackson2 libraries, required by AWS SDK v1 for sending SNS/SES notifications.

### Related Issues
https://github.com/opensearch-project/notifications/issues/1053
https://github.com/opensearch-project/dashboards-notifications/issues/376

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

(This is my first PR into a public project, so please be gentle)