### PR TITLE
Support keystore references in notification configs

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -146,6 +146,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}" // Needed for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -132,6 +132,9 @@ configurations.all {
             if (details.requested.group.startsWith('tools.jackson')) {
                 details.useVersion versions.jackson3
             }
+            if (details.requested.group == 'software.amazon.awssdk') {
+                details.useVersion versions.aws
+            }
         }
         force "commons-logging:commons-logging:1.3.5"
         force "commons-codec:commons-codec:1.17.1"
@@ -142,9 +145,6 @@ configurations.all {
         force "jakarta.json:jakarta.json-api:2.1.3"
         force "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
         force "org.slf4j:slf4j-api:${versions.slf4j}"
-        force "software.amazon.awssdk:bom:${versions.aws}"
-        force "software.amazon.awssdk:kms:${versions.aws}"
-        force "software.amazon.awssdk:dynamodb:${versions.aws}"
         force "com.amazonaws:aws-java-sdk-core:${aws_version}"
         force "com.amazonaws:aws-java-sdk-dynamodb:${aws_version}"
         force "com.amazonaws:aws-java-sdk-s3:${aws_version}"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -210,8 +210,9 @@ dependencies {
     implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
         exclude group: 'org.bouncycastle'
-        // core already bundles jackson-databind and httpcore (classic) and shares its
+        // core already bundles Jackson 2 and httpcore (classic) and shares its
         // classloader; avoid second copies
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     }

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -132,9 +132,6 @@ configurations.all {
             if (details.requested.group.startsWith('tools.jackson')) {
                 details.useVersion versions.jackson3
             }
-            if (details.requested.group == 'software.amazon.awssdk') {
-                details.useVersion versions.aws
-            }
         }
         force "commons-logging:commons-logging:1.3.5"
         force "commons-codec:commons-codec:1.17.1"
@@ -145,6 +142,11 @@ configurations.all {
         force "jakarta.json:jakarta.json-api:2.1.3"
         force "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
         force "org.slf4j:slf4j-api:${versions.slf4j}"
+        force "software.amazon.awssdk:bom:${versions.aws}"
+        force "software.amazon.awssdk:kms:${versions.aws}"
+        force "software.amazon.awssdk:dynamodb:${versions.aws}"
+        force "software.amazon.awssdk:sts:${versions.aws}"
+        force "software.amazon.awssdk:netty-nio-client:${versions.aws}"
         force "com.amazonaws:aws-java-sdk-core:${aws_version}"
         force "com.amazonaws:aws-java-sdk-dynamodb:${aws_version}"
         force "com.amazonaws:aws-java-sdk-s3:${aws_version}"

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -48,11 +48,13 @@ import org.opensearch.notifications.settings.PluginSettings.REMOTE_METADATA_SERV
 import org.opensearch.notifications.settings.PluginSettings.REMOTE_METADATA_STORE_TYPE
 import org.opensearch.notifications.spi.NotificationCore
 import org.opensearch.notifications.spi.NotificationCoreExtension
+import org.opensearch.notifications.util.NotificationConfigSecrets
 import org.opensearch.notifications.util.PluginClient
 import org.opensearch.notifications.util.SecureIndexClient
 import org.opensearch.plugins.ActionPlugin
 import org.opensearch.plugins.IdentityAwarePlugin
 import org.opensearch.plugins.Plugin
+import org.opensearch.plugins.ReloadablePlugin
 import org.opensearch.plugins.SystemIndexPlugin
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory
 import org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY
@@ -75,10 +77,11 @@ import java.util.function.Supplier
  * Entry point of the OpenSearch Notifications plugin
  * This class initializes the rest handlers.
  */
-class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, SystemIndexPlugin, IdentityAwarePlugin {
+class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, SystemIndexPlugin, IdentityAwarePlugin, ReloadablePlugin {
 
     lateinit var clusterService: ClusterService // initialized in createComponents()
     private var pluginClient: PluginClient? = null
+    private var configSecrets: NotificationConfigSecrets? = null
 
     internal companion object {
         private val log by logger(NotificationPlugin::class.java)
@@ -98,7 +101,7 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
      */
     override fun getSettings(): List<Setting<*>> {
         log.debug("$LOG_PREFIX:getSettings")
-        return PluginSettings.getAllSettings()
+        return PluginSettings.getAllSettings() + NotificationConfigSecrets.SETTING
     }
 
     /**
@@ -136,6 +139,8 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
         log.debug("$LOG_PREFIX:createComponents")
         this.clusterService = clusterService
         val settings = environment.settings()
+        val notificationConfigSecrets = NotificationConfigSecrets(settings)
+        configSecrets = notificationConfigSecrets
         val sdkClient = SdkClientFactory.createSdkClient(
             SecureIndexClient(client),
             xContentRegistry,
@@ -167,8 +172,16 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
         )
         NotificationConfigIndex.initialize(sdkClient, searchSdkClient, client, clusterService)
         ConfigIndexingActions.initialize(NotificationConfigIndex, UserAccessManager)
-        SendMessageActionHelper.initialize(NotificationConfigIndex, UserAccessManager)
+        SendMessageActionHelper.initialize(NotificationConfigIndex, UserAccessManager, notificationConfigSecrets::resolve)
         return listOf(sdkClient, pluginClientInstance)
+    }
+
+    override fun reload(settings: Settings) {
+        configSecrets?.reload(settings)
+    }
+
+    override fun close() {
+        configSecrets?.close()
     }
 
     override fun assignSubject(pluginSubject: PluginSubject) {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -66,10 +66,16 @@ object SendMessageActionHelper {
 
     private lateinit var configOperations: ConfigOperations
     private lateinit var userAccess: UserAccess
+    private var resolveSecureValue: (String, String) -> String = { _, value -> value }
 
-    fun initialize(configOperations: ConfigOperations, userAccess: UserAccess) {
+    fun initialize(
+        configOperations: ConfigOperations,
+        userAccess: UserAccess,
+        resolveSecureValue: (String, String) -> String = { _, value -> value }
+    ) {
         this.configOperations = configOperations
         this.userAccess = userAccess
+        this.resolveSecureValue = resolveSecureValue
     }
 
     /**
@@ -225,11 +231,18 @@ object SendMessageActionHelper {
 
         val response = when (configType) {
             ConfigType.NONE -> null
-            ConfigType.SLACK -> sendSlackMessage(configData as Slack, message, eventStatus, eventSource.referenceId)
-            ConfigType.MATTERMOST -> sendSlackMessage(configData as Slack, message, eventStatus, eventSource.referenceId)
-            ConfigType.CHIME -> sendChimeMessage(configData as Chime, message, eventStatus, eventSource.referenceId)
-            ConfigType.MICROSOFT_TEAMS -> sendMicrosoftTeamsMessage(configData as MicrosoftTeams, message, eventStatus, eventSource.referenceId)
+            ConfigType.SLACK -> sendSlackMessage(channel.docInfo.id!!, configData as Slack, message, eventStatus, eventSource.referenceId)
+            ConfigType.MATTERMOST -> sendSlackMessage(channel.docInfo.id!!, configData as Slack, message, eventStatus, eventSource.referenceId)
+            ConfigType.CHIME -> sendChimeMessage(channel.docInfo.id!!, configData as Chime, message, eventStatus, eventSource.referenceId)
+            ConfigType.MICROSOFT_TEAMS -> sendMicrosoftTeamsMessage(
+                channel.docInfo.id!!,
+                configData as MicrosoftTeams,
+                message,
+                eventStatus,
+                eventSource.referenceId
+            )
             ConfigType.WEBHOOK -> sendWebhookMessage(
+                channel.docInfo.id!!,
                 configData as Webhook,
                 message,
                 eventStatus,
@@ -366,13 +379,14 @@ object SendMessageActionHelper {
      * send message to slack destination
      */
     private fun sendSlackMessage(
+        configId: String,
         slack: Slack,
         message: MessageContent,
         eventStatus: EventStatus,
         referenceId: String
     ): EventStatus {
         Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_SLACK.counter.increment()
-        val destination = SlackDestination(slack.url)
+        val destination = SlackDestination(resolveSecureValue(configId, slack.url))
         val status = sendMessageThroughSpi(destination, message, referenceId)
         return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
@@ -381,13 +395,14 @@ object SendMessageActionHelper {
      * send message to chime destination
      */
     private fun sendChimeMessage(
+        configId: String,
         chime: Chime,
         message: MessageContent,
         eventStatus: EventStatus,
         referenceId: String
     ): EventStatus {
         Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_CHIME.counter.increment()
-        val destination = ChimeDestination(chime.url)
+        val destination = ChimeDestination(resolveSecureValue(configId, chime.url))
         val status = sendMessageThroughSpi(destination, message, referenceId)
         return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
@@ -396,13 +411,14 @@ object SendMessageActionHelper {
      * send message to Microsoft Teams destination
      */
     private fun sendMicrosoftTeamsMessage(
+        configId: String,
         microsoftTeams: MicrosoftTeams,
         message: MessageContent,
         eventStatus: EventStatus,
         referenceId: String
     ): EventStatus {
         Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_MICROSOFT_TEAMS.counter.increment()
-        val destination = MicrosoftTeamsDestination(microsoftTeams.url)
+        val destination = MicrosoftTeamsDestination(resolveSecureValue(configId, microsoftTeams.url))
         val status = sendMessageThroughSpi(destination, message, referenceId)
         return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }
@@ -411,13 +427,18 @@ object SendMessageActionHelper {
      * send message to custom webhook destination
      */
     private fun sendWebhookMessage(
+        configId: String,
         webhook: Webhook,
         message: MessageContent,
         eventStatus: EventStatus,
         referenceId: String
     ): EventStatus {
         Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_WEBHOOK.counter.increment()
-        val destination = CustomWebhookDestination(webhook.url, webhook.headerParams, webhook.method.tag)
+        val destination = CustomWebhookDestination(
+            resolveSecureValue(configId, webhook.url),
+            webhook.headerParams.mapValues { resolveSecureValue(configId, it.value) },
+            webhook.method.tag
+        )
         val status = sendMessageThroughSpi(destination, message, referenceId)
         return eventStatus.copy(deliveryStatus = DeliveryStatus(status.statusCode.toString(), status.statusText))
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/NotificationConfigSecrets.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/util/NotificationConfigSecrets.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.util
+
+import org.opensearch.common.settings.SecureSetting
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.settings.SettingsException
+import org.opensearch.core.common.settings.SecureString
+import java.util.Collections
+
+internal class NotificationConfigSecrets(settings: Settings) : AutoCloseable {
+    companion object {
+        const val SETTING_PREFIX = "opensearch.notifications.keystore."
+
+        val SETTING: Setting.AffixSetting<SecureString> = Setting.prefixKeySetting(SETTING_PREFIX) { key ->
+            SecureSetting.secureString(key, null)
+        }
+
+        private val REFERENCE_PATTERN = Regex("\\$\\{keystore:([A-Za-z0-9_.-]+)}")
+    }
+
+    private var secrets: Map<String, CharArray> = load(settings)
+
+    @Synchronized
+    fun resolve(configId: String, value: String): String {
+        return REFERENCE_PATTERN.replace(value) { matchResult ->
+            val alias = matchResult.groupValues[1]
+            val settingName = "$configId.$alias"
+            val secret = secrets[settingName]
+                ?: throw SettingsException("Keystore setting [$SETTING_PREFIX$settingName] referenced by notification configuration is missing")
+            String(secret)
+        }
+    }
+
+    @Synchronized
+    fun reload(settings: Settings) {
+        val replacement = load(settings)
+        val previous = secrets
+        secrets = replacement
+        clear(previous)
+    }
+
+    @Synchronized
+    override fun close() {
+        clear(secrets)
+        secrets = emptyMap()
+    }
+
+    private fun load(settings: Settings): Map<String, CharArray> {
+        val loaded = mutableMapOf<String, CharArray>()
+        try {
+            SETTING.getAsMap(settings).forEach { (alias, secureString) ->
+                secureString.use {
+                    loaded[alias] = it.chars.clone()
+                }
+            }
+            return Collections.unmodifiableMap(loaded)
+        } catch (exception: RuntimeException) {
+            clear(loaded)
+            throw exception
+        }
+    }
+
+    private fun clear(values: Map<String, CharArray>) {
+        values.values.forEach { it.fill('\u0000') }
+    }
+}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/NotificationConfigSecretsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/util/NotificationConfigSecretsTests.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.opensearch.common.settings.SecureSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.settings.SettingsException
+import org.opensearch.commons.notifications.model.Slack
+import org.opensearch.core.common.settings.SecureString
+import java.io.InputStream
+
+internal class NotificationConfigSecretsTests {
+    @Test
+    fun `resolves embedded keystore references`() {
+        val secrets = NotificationConfigSecrets(settings(mapOf("config-1.slack.path" to "T000/B000/secret")))
+        val slack = Slack("https://hooks.slack.com/services/\${keystore:slack.path}")
+
+        val resolved = secrets.resolve("config-1", slack.url)
+
+        assertEquals("https://hooks.slack.com/services/T000/B000/secret", resolved)
+    }
+
+    @Test
+    fun `resolves complete header value references`() {
+        val secrets = NotificationConfigSecrets(settings(mapOf("config-1.webhook.token" to "Bearer secret")))
+
+        assertEquals("Bearer secret", secrets.resolve("config-1", "\${keystore:webhook.token}"))
+    }
+
+    @Test
+    fun `references are scoped to the notification config`() {
+        val secrets = NotificationConfigSecrets(settings(mapOf("config-1.webhook.token" to "Bearer secret")))
+
+        assertThrows(SettingsException::class.java) {
+            secrets.resolve("config-2", "\${keystore:webhook.token}")
+        }
+    }
+
+    @Test
+    fun `reload replaces secret values`() {
+        val secrets = NotificationConfigSecrets(settings(mapOf("config-1.slack.path" to "old")))
+
+        secrets.reload(settings(mapOf("config-1.slack.path" to "new")))
+
+        assertEquals("https://example.com/new", secrets.resolve("config-1", "https://example.com/\${keystore:slack.path}"))
+    }
+
+    @Test
+    fun `missing keystore reference is rejected`() {
+        val secrets = NotificationConfigSecrets(Settings.EMPTY)
+
+        assertThrows(SettingsException::class.java) {
+            secrets.resolve("config-1", "\${keystore:missing}")
+        }
+    }
+
+    @Test
+    fun `plain values pass through unchanged`() {
+        val secrets = NotificationConfigSecrets(Settings.EMPTY)
+
+        assertEquals("https://example.com/path", secrets.resolve("config-1", "https://example.com/path"))
+    }
+
+    private fun settings(values: Map<String, String>): Settings {
+        return Settings.builder().setSecureSettings(TestSecureSettings(values)).build()
+    }
+
+    private class TestSecureSettings(private val values: Map<String, String>) : SecureSettings {
+        override fun isLoaded() = true
+
+        override fun getSettingNames(): Set<String> = values.keys.map { NotificationConfigSecrets.SETTING_PREFIX + it }.toSet()
+
+        override fun getString(setting: String): SecureString {
+            return SecureString(values.getValue(setting.removePrefix(NotificationConfigSecrets.SETTING_PREFIX)).toCharArray())
+        }
+
+        override fun getFile(setting: String): InputStream = throw UnsupportedOperationException()
+
+        override fun getSHA256Digest(setting: String): ByteArray = throw UnsupportedOperationException()
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
## Summary
- register config-scoped secure settings under `opensearch.notifications.keystore.<config-id>.<alias>`
- allow notification URLs and webhook header values to contain `${keystore:<alias>}` references
- resolve references only when constructing a destination, keeping secrets out of the system index and configuration APIs
- implement `ReloadablePlugin` so `_nodes/reload_secure_settings` refreshes the in-memory values
- clear prior character arrays on reload and shutdown

## Example
Add a node-local value on every node that can send notifications:

```console
bin/opensearch-keystore add opensearch.notifications.keystore.<config-id>.slack.path
```

Store the reference in the notification configuration:

```text
https://hooks.slack.com/services/${keystore:slack.path}
```

After changing keystore files, reload them through the OpenSearch nodes reload secure settings API.

## Design discussion
This is an exploratory alternative to https://github.com/opensearch-project/notifications/pull/1218. Rather than encrypting secret material into `.opensearch-notifications-config`, it stores an explicit reference and obtains the value from each node OpenSearch keystore at send time. The system index remains searchable for non-secret structure, and the implementation does not require encryption-key rotation or ciphertext migration.

The current prototype intentionally scopes aliases by notification config ID so one configuration cannot reference another configuration secret alias.

## Open questions and limitations
- Every node that can send a notification must have the referenced value in its local keystore.
- Auto-generated configuration IDs require provisioning the scoped setting after creation, followed by secure-settings reload.
- Existing common-utils URL validation rejects a URL whose entire value is `${keystore:...}`. This prototype therefore demonstrates embedded URL references; a production design may need a common-utils change to recognize exact reference tokens.
- Embedded references in generic webhook URLs require additional threat-model review: a user allowed to edit the surrounding URL could redirect the resolved secret. Whole-field references or stronger validation/immutability constraints would reduce that risk.

This draft is intended to compare the keystore-reference approach with encrypted system-index storage before settling the API and authorization model.

## Testing
- `./gradlew :notifications:test`
- `ktlint` (run by the Gradle build)