### PR TITLE
Fix Notifications CI dependency failures

### DIFF
--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -146,6 +146,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}" // Needed for amazonaws (org.apache.http.protocol.HttpRequestExecutor)
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -145,6 +145,8 @@ configurations.all {
         force "software.amazon.awssdk:bom:${versions.aws}"
         force "software.amazon.awssdk:kms:${versions.aws}"
         force "software.amazon.awssdk:dynamodb:${versions.aws}"
+        force "software.amazon.awssdk:sts:${versions.aws}"
+        force "software.amazon.awssdk:netty-nio-client:${versions.aws}"
         force "com.amazonaws:aws-java-sdk-core:${aws_version}"
         force "com.amazonaws:aws-java-sdk-dynamodb:${aws_version}"
         force "com.amazonaws:aws-java-sdk-s3:${aws_version}"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -210,8 +210,9 @@ dependencies {
     implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}") {
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-core'
         exclude group: 'org.bouncycastle'
-        // core already bundles jackson-databind and httpcore (classic) and shares its
+        // core already bundles Jackson 2 and httpcore (classic) and shares its
         // classloader; avoid second copies
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     }


### PR DESCRIPTION
## Summary
- align the remote metadata client STS and Netty dependencies with the AWS SDK v2 version selected by OpenSearch
- add Jackson 2 core explicitly to the Notifications core runtime classpath
- restore successful dependency resolution and SES/SNS client construction

## Motivation
Current CI first fails while resolving the remote metadata DDB client because its published snapshot requests STS and Netty `2.32.29`, while the current OpenSearch dependency catalog selects `2.54.2` for other AWS SDK modules. The existing force list aligns the BOM, KMS, and DynamoDB but omits these two transitive modules.

After resolving that conflict, the build reaches the SES/SNS regression tests added in #1257 and fails because `com.fasterxml.jackson.core.Versioned` is absent. `jackson-databind` is declared, but Jackson 2 core is not present in the resolved plugin runtime classpath; the existing `force` entry only controls its version if another dependency introduces it.

This change pins only the two conflicting AWS SDK modules and adds the missing direct Jackson runtime dependency.

## Testing
- `./gradlew build -x integTest -x jacocoTestReport`
- `./gradlew :opensearch-notifications-core:test --tests org.opensearch.notifications.core.credentials.SesClientFactoryImplTests --tests org.opensearch.notifications.core.credentials.SnsClientFactoryImplTests`
- `./gradlew :notifications:dependencyLicenses :notifications:bundlePlugin ktlint`